### PR TITLE
Add MarkdownStrategy to preserve code in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Different file types are handled by different strategies, configured in `config.
 
 | Strategy | Extensions | Behaviour |
 |----------|------------|-----------|
-| **text** | `.txt`, `.md` | Convert everything |
+| **text** | `.txt` | Convert everything |
+| **markdown** | `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx` | Preserve code spans and code blocks |
 | **latex** | `.tex` | Skip LaTeX commands and math |
 | **html** | `.html`, `.htm`, `.xml` | Skip HTML tags |
 | **json** | `.json` | Only convert string values |

--- a/config.json
+++ b/config.json
@@ -3,7 +3,11 @@
   "strategies": {
     "text": {
       "description": "Plain text - convert everything",
-      "extensions": [".txt", ".md"]
+      "extensions": [".txt"]
+    },
+    "markdown": {
+      "description": "Markdown - preserve code spans and code blocks",
+      "extensions": [".md", ".markdown", ".mdown", ".mkd", ".mdx"]
     },
     "latex": {
       "description": "LaTeX - skip commands and math",


### PR DESCRIPTION
## Summary
- New MarkdownStrategy preserves inline code spans and fenced code blocks
- Supports variable-length fences (4+ backticks to nest triple backticks)
- Handles indented closing fences (up to 3 spaces)
- Preserves indented code blocks (4 spaces or tab)
- Added .markdown, .mdown, .mkd, .mdx extensions
- Added 17 new tests for markdown handling (55 total, all passing)