### PR TITLE
Add CssStrategy and fix inline CSS/JS preservation in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Different file types are handled by different strategies, configured in `config.
 | **text** | `.txt` | Convert everything |
 | **markdown** | `.md`, `.markdown`, `.mdown`, `.mkd`, `.mdx` | Preserve code spans and code blocks |
 | **latex** | `.tex` | Skip LaTeX commands and math |
-| **html** | `.html`, `.htm`, `.xml` | Skip HTML tags |
+| **html** | `.html`, `.htm`, `.xml` | Skip HTML tags and `<style>`/`<script>` content |
+| **css** | `.css`, `.scss`, `.sass`, `.less` | Only convert comments |
 | **json** | `.json` | Only convert string values |
 | **code** | `.py`, `.js`, `.ts`, etc. | Only convert comments and docstrings |
 

--- a/config.json
+++ b/config.json
@@ -17,6 +17,10 @@
       "description": "HTML/XML - skip tags",
       "extensions": [".html", ".htm", ".xml"]
     },
+    "css": {
+      "description": "CSS/SCSS/SASS/LESS - only convert comments",
+      "extensions": [".css", ".scss", ".sass", ".less"]
+    },
     "json": {
       "description": "JSON - only convert string values",
       "extensions": [".json"]


### PR DESCRIPTION
## Summary
- Add `CssStrategy` for `.css/.scss/.sass/.less` files - only converts text in comments, preserves all CSS properties and values
- Fix `HTMLStrategy` to preserve `<style>` and `<script>` tag content (inline CSS/JS was being converted)
- Fix `//` false positive in CSS - URLs like `url(//cdn.example.com)` and `http://` are no longer treated as comments

## Changes
- **CssStrategy**: New strategy that only converts comments (`/* */` and `//`), preserves CSS properties like `color`, `center`, etc.
- **HTMLStrategy**: Process `<script>` before `<style>` to handle inline style strings in JS; use UUID-based placeholders to prevent collisions
- **config.json**: Added CSS strategy entry
- **README.md**: Updated file type strategies table

## Test plan
- [x] All 91 tests pass
- [x] New tests for CSS URL handling (protocol-relative, http://, https://)
- [x] New tests for script containing inline `<style>` strings
- [x] Negative mapping assertions added
- [x] Manual verification with `britfix --input test.css`