### PR TITLE
Fix infinite loop when processing tildes not at line start

### DIFF
--- a/britfix_core.py
+++ b/britfix_core.py
@@ -356,7 +356,13 @@ class MarkdownStrategy(FileProcessingStrategy):
                 for word, count in changes.items():
                     total_changes[word] += count
 
-            i = next_code
+            # If we're at a delimiter that wasn't handled as a code block
+            # (e.g., tilde not at line start like "~7 days"), just add it and advance
+            if next_code == i:
+                result.append(content[i])
+                i += 1
+            else:
+                i = next_code
 
         return ''.join(result), dict(total_changes)
 


### PR DESCRIPTION
## Summary
- Fixed 100% CPU infinite loop when processing markdown files containing tildes not at line start (e.g., `~7 days` for approximate values)
- Root cause: `MarkdownStrategy.process()` searched for tildes as potential fence delimiters but didn't advance past them when they weren't valid fences, causing `i = next_code` to not advance
- Added check to advance by 1 character when `next_code == i` to prevent stalling

## Test plan
- [x] Added regression test with timeout detection (`test_tilde_not_at_line_start_no_infinite_loop`)
- [x] Added test for prose conversion around tildes (`test_tilde_in_prose_converts_surrounding_text`)
- [x] All 93 tests passing
- [x] Verified fix on the actual file that was causing the issue (`cheeky-drifting-clarke.md` with `~7 days`)