### PR TITLE
Add .britfixignore exception mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ markdown:dialog
 
 ### File Discovery
 
-Britfix walks up from the target file to the nearest `.git` boundary (or home directory), collecting `.britfixignore` files from root to leaf. All found files are merged additively.
+Britfix walks up from the target file, stopping at the first `.git` boundary, the home directory, or the filesystem root (whichever is found first). It collects `.britfixignore` files from that boundary down to the file's directory, merging them additively.
 
 ### User-Level Config
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,57 @@ payload = {'colorScheme': x}    # Dict key - unchanged
 # Use 'colorField' for the API  # Quoted in comment - unchanged
 ```
 
+## Ignoring Words (`.britfixignore`)
+
+Create a `.britfixignore` file to prevent specific words from being converted. This is useful for words like "dialog", "color", or "center" that are conventional American spellings in technical contexts.
+
+### Format
+
+```text
+# Global exceptions (all strategies)
+dialog
+
+# Strategy-scoped exceptions (only apply to that file type)
+code:color
+code:center
+markdown:dialog
+```
+
+- One word per line, `#` comments, blank lines skipped
+- Optional `strategy:` prefix scopes the exception to that strategy only
+- Words use American (source) spelling (e.g. `color` not `colour`)
+- Case-insensitive
+
+### File Discovery
+
+Britfix walks up from the target file to the nearest `.git` boundary (or home directory), collecting `.britfixignore` files from root to leaf. All found files are merged additively.
+
+### User-Level Config
+
+A personal ignore file applies to all projects:
+
+- **Linux/macOS**: `~/.config/britfix/ignore` (or `$XDG_CONFIG_HOME/britfix/ignore` if set)
+- **Windows**: `%APPDATA%\britfix\ignore`
+
+### Example
+
+With this `.britfixignore` at your project root:
+```text
+code:color
+code:center
+```
+
+Running britfix on a Python file:
+```python
+# The color is nice   ->  unchanged (code:color exception)
+# The behavior is ok  ->  # The behaviour is ok (not excepted)
+```
+
+Running britfix on a text file:
+```text
+The color is nice  ->  The colour is nice (exception is code-scoped, doesn't apply)
+```
+
 ## Configuration
 
 Edit `config.json` to customise file type handling:

--- a/britfix.py
+++ b/britfix.py
@@ -50,6 +50,11 @@ from britfix_core import (
     SpellingCorrector,
     load_spelling_mappings,
     get_file_strategy,
+    get_file_strategy_name,
+    discover_ignore_words,
+    get_corrector_for_strategy,
+    get_user_ignore_path,
+    parse_britfixignore,
 )
 
 
@@ -325,9 +330,6 @@ Examples:
         logging.error("No spelling dictionary found or dictionary is empty")
         sys.exit(1)
     
-    # Create corrector
-    corrector = SpellingCorrector(american_to_british)
-    
     # Handle stdin input or file patterns
     if not args.input:
         # Check if stdin has data
@@ -337,12 +339,27 @@ Examples:
         
         # Process stdin (treated as plain text)
         content = sys.stdin.read()
+
+        # For stdin, use only user-level ignore with "text" strategy
+        stdin_global = set()
+        stdin_scoped: dict = {}
+        user_ignore_path = get_user_ignore_path()
+        if user_ignore_path and user_ignore_path.is_file():
+            try:
+                user_content = user_ignore_path.read_text(encoding='utf-8')
+                stdin_global, stdin_scoped = parse_britfixignore(user_content)
+            except (OSError, UnicodeDecodeError):
+                pass
+        stdin_corrector = get_corrector_for_strategy(
+            american_to_british, stdin_global, stdin_scoped, 'text'
+        )
+
         if args.interactive:
-            corrected_content, changes = process_stdin_interactive(content, corrector)
+            corrected_content, changes = process_stdin_interactive(content, stdin_corrector)
         else:
             # Non-interactive stdin processing
             strategy = get_file_strategy('.txt')  # Default to text strategy
-            corrected_content, changes = strategy.process(content, corrector)
+            corrected_content, changes = strategy.process(content, stdin_corrector)
         
         # Output result to stdout
         if not args.dry_run:
@@ -379,14 +396,21 @@ Examples:
             # Get the appropriate processing strategy
             ext = os.path.splitext(filepath)[1].lower()
             strategy = get_file_strategy(ext)
+            strategy_name = get_file_strategy_name(ext)
+
+            # Discover ignore words for this file (cached by directory)
+            file_global, file_scoped = discover_ignore_words(filepath)
+            file_corrector = get_corrector_for_strategy(
+                american_to_british, file_global, file_scoped, strategy_name
+            )
 
             # Process the file
             if args.interactive:
-                corrected_content, file_changes = process_file_interactive(filepath, corrector)
+                corrected_content, file_changes = process_file_interactive(filepath, file_corrector)
             else:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     content = f.read()
-                corrected_content, file_changes = strategy.process(content, corrector)
+                corrected_content, file_changes = strategy.process(content, file_corrector)
             
             if file_changes:
                 processed_files.append((filepath, file_changes))

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -1087,7 +1087,9 @@ def filter_dictionary(
     return {k: v for k, v in dictionary.items() if k.lower() not in all_ignored}
 
 
-# Cache for correctors keyed by (dict_len, strategy_name, frozenset(ignored))
+# Cache for correctors keyed by (dict_id, strategy_name, frozenset(ignored)).
+# Uses id() for the dictionary — safe because the dictionary object is kept alive
+# for the entire CLI run, so the id cannot be reused by a different object.
 _corrector_cache: Dict[Tuple[int, str, frozenset], SpellingCorrector] = {}
 
 
@@ -1101,7 +1103,7 @@ def get_corrector_for_strategy(
     strategy_ignores = scoped_ignores.get(strategy_name, set())
     effective_ignored = frozenset(global_ignores | strategy_ignores)
 
-    cache_key = (len(base_dictionary), strategy_name, effective_ignored)
+    cache_key = (id(base_dictionary), strategy_name, effective_ignored)
     if cache_key in _corrector_cache:
         return _corrector_cache[cache_key]
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -6,6 +6,7 @@ import json
 import os
 import sys
 import uuid
+from pathlib import Path
 from typing import Dict, List, Tuple, Optional, Set
 from collections import defaultdict
 
@@ -872,9 +873,12 @@ _STRATEGY_INSTANCES = {
     'code': CodeStrategy(),
 }
 
-# Build file extension to strategy mapping from config
-def _build_file_strategies() -> Dict[str, FileProcessingStrategy]:
-    """Build FILE_STRATEGIES from config.json."""
+# Build unified file extension to (strategy_name, strategy_instance) mapping from config
+def _build_file_strategies() -> Dict[str, Tuple[str, FileProcessingStrategy]]:
+    """Build FILE_STRATEGIES from config.json.
+
+    Returns a map of {ext: (strategy_name, strategy_instance)}.
+    """
     strategies = {}
     config_strategies = _CONFIG['strategies']
 
@@ -882,7 +886,7 @@ def _build_file_strategies() -> Dict[str, FileProcessingStrategy]:
         strategy_instance = _STRATEGY_INSTANCES.get(strategy_name)
         if strategy_instance:
             for ext in strategy_config['extensions']:
-                strategies[ext.lower()] = strategy_instance
+                strategies[ext.lower()] = (strategy_name, strategy_instance)
 
     return strategies
 
@@ -900,9 +904,208 @@ CODE_EXTENSIONS = _build_code_extensions()
 
 def get_file_strategy(file_extension: str) -> FileProcessingStrategy:
     """Get the appropriate processing strategy for a file type."""
-    return FILE_STRATEGIES.get(file_extension.lower(), PlainTextStrategy())
+    entry = FILE_STRATEGIES.get(file_extension.lower())
+    if entry:
+        return entry[1]
+    return PlainTextStrategy()
+
+
+def get_file_strategy_name(file_extension: str) -> str:
+    """Get the strategy name for a file extension, defaulting to 'text'."""
+    entry = FILE_STRATEGIES.get(file_extension.lower())
+    if entry:
+        return entry[0]
+    return 'text'
 
 
 def is_code_file(file_extension: str) -> bool:
     """Check if file extension is a code file."""
     return file_extension.lower() in CODE_EXTENSIONS
+
+
+# --- .britfixignore support ---
+
+def parse_britfixignore(content: str) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    """Parse a .britfixignore file.
+
+    Returns (global_ignores, scoped_ignores) where scoped_ignores maps
+    strategy name -> set of words. Words are lowercased. Unknown strategy
+    names produce a warning on stderr and are skipped.
+    """
+    valid_strategies = set(_CONFIG['strategies'].keys())
+    global_ignores: Set[str] = set()
+    scoped_ignores: Dict[str, Set[str]] = {}
+
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+
+        if ':' in line:
+            strategy_name, _, word = line.partition(':')
+            strategy_name = strategy_name.strip().lower()
+            word = word.strip().lower()
+            if not word:
+                continue
+            if strategy_name not in valid_strategies:
+                safe_name = strategy_name.encode('unicode_escape').decode('ascii')
+                print(f"britfix: unknown strategy '{safe_name}' in .britfixignore, skipping", file=sys.stderr)
+                continue
+            if strategy_name not in scoped_ignores:
+                scoped_ignores[strategy_name] = set()
+            scoped_ignores[strategy_name].add(word)
+        else:
+            global_ignores.add(line.lower())
+
+    return global_ignores, scoped_ignores
+
+
+def get_user_ignore_path() -> Optional[Path]:
+    """Get the user-level britfix ignore config path.
+
+    Windows: %APPDATA%/britfix/ignore
+    Others: $XDG_CONFIG_HOME/britfix/ignore (default ~/.config/britfix/ignore)
+    """
+    if os.name == 'nt':
+        appdata = os.environ.get('APPDATA', '')
+        if appdata:
+            return Path(appdata) / 'britfix' / 'ignore'
+        return None
+    else:
+        xdg = os.environ.get('XDG_CONFIG_HOME', '')
+        if xdg:
+            base = Path(xdg)
+        else:
+            base = Path.home() / '.config'
+        return base / 'britfix' / 'ignore'
+
+
+# Cache for ignore lookups by directory path
+_ignore_cache: Dict[str, Tuple[Set[str], Dict[str, Set[str]]]] = {}
+
+
+def _merge_ignores(
+    base: Tuple[Set[str], Dict[str, Set[str]]],
+    overlay: Tuple[Set[str], Dict[str, Set[str]]],
+) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    """Merge two ignore tuples additively (union)."""
+    merged_global = base[0] | overlay[0]
+    merged_scoped: Dict[str, Set[str]] = {}
+    for key in set(base[1].keys()) | set(overlay[1].keys()):
+        merged_scoped[key] = base[1].get(key, set()) | overlay[1].get(key, set())
+    return merged_global, merged_scoped
+
+
+def discover_ignore_words(file_path: str) -> Tuple[Set[str], Dict[str, Set[str]]]:
+    """Discover .britfixignore words for a given file.
+
+    Walks up from the file's directory to the nearest .git boundary or
+    Path.home(), collects .britfixignore files root->leaf, merges with
+    user config. Results are cached by directory.
+    """
+    resolved = Path(file_path).resolve()
+    file_dir = resolved.parent if resolved.is_file() or not resolved.exists() else resolved
+
+    cache_key = str(file_dir)
+    if cache_key in _ignore_cache:
+        return _ignore_cache[cache_key]
+
+    home = Path.home()
+
+    # Walk up to find boundary
+    boundary = None
+    current = file_dir
+    while True:
+        git_path = current / '.git'
+        if git_path.exists():
+            boundary = current
+            break
+        if current == home:
+            boundary = home
+            break
+        parent = current.parent
+        if parent == current:
+            # Filesystem root
+            boundary = current
+            break
+        current = parent
+
+    # Collect .britfixignore files from boundary down to file_dir
+    # Build the path from boundary to file_dir
+    ignore_files: List[Path] = []
+    try:
+        rel = file_dir.relative_to(boundary)
+        parts = [boundary] + [boundary / Path(*rel.parts[:i+1]) for i in range(len(rel.parts))]
+    except ValueError:
+        parts = [file_dir]
+
+    for d in parts:
+        candidate = d / '.britfixignore'
+        if candidate.is_file():
+            ignore_files.append(candidate)
+
+    # Start with user config
+    result: Tuple[Set[str], Dict[str, Set[str]]] = (set(), {})
+    user_path = get_user_ignore_path()
+    if user_path and user_path.is_file():
+        try:
+            user_content = user_path.read_text(encoding='utf-8')
+            result = parse_britfixignore(user_content)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    # Merge project ignores root->leaf
+    for ignore_file in ignore_files:
+        try:
+            content = ignore_file.read_text(encoding='utf-8')
+            parsed = parse_britfixignore(content)
+            result = _merge_ignores(result, parsed)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+    _ignore_cache[cache_key] = result
+    return result
+
+
+def filter_dictionary(
+    dictionary: Dict[str, str],
+    global_ignores: Set[str],
+    scoped_ignores: Dict[str, Set[str]],
+    strategy_name: str,
+) -> Dict[str, str]:
+    """Filter a spelling dictionary by removing ignored words.
+
+    global_ignores apply to all strategies. scoped_ignores[strategy_name]
+    applies only to the given strategy. Words are matched case-insensitively.
+    """
+    strategy_ignores = scoped_ignores.get(strategy_name, set())
+    all_ignored = global_ignores | strategy_ignores
+
+    if not all_ignored:
+        return dictionary
+
+    return {k: v for k, v in dictionary.items() if k.lower() not in all_ignored}
+
+
+# Cache for correctors keyed by (dict_len, strategy_name, frozenset(ignored))
+_corrector_cache: Dict[Tuple[int, str, frozenset], SpellingCorrector] = {}
+
+
+def get_corrector_for_strategy(
+    base_dictionary: Dict[str, str],
+    global_ignores: Set[str],
+    scoped_ignores: Dict[str, Set[str]],
+    strategy_name: str,
+) -> SpellingCorrector:
+    """Get a (cached) SpellingCorrector with ignored words filtered out."""
+    strategy_ignores = scoped_ignores.get(strategy_name, set())
+    effective_ignored = frozenset(global_ignores | strategy_ignores)
+
+    cache_key = (len(base_dictionary), strategy_name, effective_ignored)
+    if cache_key in _corrector_cache:
+        return _corrector_cache[cache_key]
+
+    filtered = filter_dictionary(base_dictionary, global_ignores, scoped_ignores, strategy_name)
+    corrector = SpellingCorrector(filtered)
+    _corrector_cache[cache_key] = corrector
+    return corrector

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -2,7 +2,9 @@
 """
 Tests for britfix - especially CodeStrategy context handling.
 """
+import os
 import pytest
+from pathlib import Path
 from britfix_core import (
     SpellingCorrector,
     load_spelling_mappings,
@@ -12,7 +14,14 @@ from britfix_core import (
     PlainTextStrategy,
     MarkdownStrategy,
     is_code_file,
-    CODE_EXTENSIONS
+    CODE_EXTENSIONS,
+    parse_britfixignore,
+    get_user_ignore_path,
+    discover_ignore_words,
+    filter_dictionary,
+    get_corrector_for_strategy,
+    get_file_strategy_name,
+    _ignore_cache,
 )
 
 
@@ -882,6 +891,396 @@ class TestCssStrategyMapping:
         strategy = get_file_strategy('.py')
         assert not isinstance(strategy, CssStrategy)
         assert isinstance(strategy, CodeStrategy)
+
+
+class TestGetFileStrategyName:
+    """Test get_file_strategy_name returns correct strategy names."""
+
+    def test_python_is_code(self):
+        assert get_file_strategy_name('.py') == 'code'
+
+    def test_md_is_markdown(self):
+        assert get_file_strategy_name('.md') == 'markdown'
+
+    def test_txt_is_text(self):
+        assert get_file_strategy_name('.txt') == 'text'
+
+    def test_css_is_css(self):
+        assert get_file_strategy_name('.css') == 'css'
+
+    def test_unknown_defaults_to_text(self):
+        assert get_file_strategy_name('.xyz') == 'text'
+
+
+class TestBritfixIgnoreParsing:
+    """Test .britfixignore file parsing."""
+
+    def test_empty_file(self):
+        g, s = parse_britfixignore('')
+        assert g == set()
+        assert s == {}
+
+    def test_comments_and_blank_lines(self):
+        content = "# a comment\n\n# another\n"
+        g, s = parse_britfixignore(content)
+        assert g == set()
+        assert s == {}
+
+    def test_global_words(self):
+        content = "color\nbehavior\n"
+        g, s = parse_britfixignore(content)
+        assert g == {'color', 'behavior'}
+        assert s == {}
+
+    def test_scoped_words(self):
+        content = "code:color\nmarkdown:dialog\n"
+        g, s = parse_britfixignore(content)
+        assert g == set()
+        assert s == {'code': {'color'}, 'markdown': {'dialog'}}
+
+    def test_mixed_global_and_scoped(self):
+        content = "color\ncode:dialog\n"
+        g, s = parse_britfixignore(content)
+        assert g == {'color'}
+        assert s == {'code': {'dialog'}}
+
+    def test_whitespace_handling(self):
+        content = "  color  \n  code : dialog  \n"
+        g, s = parse_britfixignore(content)
+        assert 'color' in g
+        assert 'dialog' in s.get('code', set())
+
+    def test_case_insensitivity(self):
+        content = "Color\nCode:Dialog\n"
+        g, s = parse_britfixignore(content)
+        assert 'color' in g
+        assert 'dialog' in s.get('code', set())
+
+    def test_unknown_strategy_warns(self, capsys):
+        content = "bogus:color\n"
+        g, s = parse_britfixignore(content)
+        assert g == set()
+        assert s == {}
+        captured = capsys.readouterr()
+        assert "unknown strategy 'bogus'" in captured.err
+
+    def test_empty_word_after_colon_skipped(self):
+        content = "code:\n"
+        g, s = parse_britfixignore(content)
+        assert g == set()
+        assert s == {}
+
+    def test_multiple_words_same_strategy(self):
+        content = "code:color\ncode:dialog\ncode:center\n"
+        g, s = parse_britfixignore(content)
+        assert s == {'code': {'color', 'dialog', 'center'}}
+
+
+class TestBritfixIgnoreDiscovery:
+    """Test .britfixignore file discovery."""
+
+    @pytest.fixture(autouse=True)
+    def clear_cache(self):
+        """Clear ignore cache before each test."""
+        _ignore_cache.clear()
+        yield
+        _ignore_cache.clear()
+
+    def test_git_root_boundary(self, tmp_path):
+        """Discovery stops at .git directory."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('color\n')
+        (tmp_path / 'sub').mkdir()
+        target = tmp_path / 'sub' / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' in g
+
+    def test_nested_dirs_merge(self, tmp_path):
+        """Nested .britfixignore files merge additively."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('color\n')
+        (tmp_path / 'sub').mkdir()
+        (tmp_path / 'sub' / '.britfixignore').write_text('behavior\n')
+        target = tmp_path / 'sub' / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' in g
+        assert 'behavior' in g
+
+    def test_scoped_merge(self, tmp_path):
+        """Scoped ignores from different levels merge."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('code:color\n')
+        (tmp_path / 'sub').mkdir()
+        (tmp_path / 'sub' / '.britfixignore').write_text('code:dialog\n')
+        target = tmp_path / 'sub' / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert s.get('code') == {'color', 'dialog'}
+
+    def test_stops_at_home_dir(self, tmp_path, monkeypatch):
+        """Discovery stops at home directory."""
+        fake_home = tmp_path / 'home'
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, 'home', staticmethod(lambda: fake_home))
+
+        # Put an ignore file ABOVE home — it should not be found
+        (tmp_path / '.britfixignore').write_text('color\n')
+        project = fake_home / 'project'
+        project.mkdir()
+        target = project / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' not in g
+
+    def test_worktree_git_file(self, tmp_path):
+        """A .git file (worktree) is also a valid boundary."""
+        (tmp_path / '.git').write_text('gitdir: /some/other/path\n')
+        (tmp_path / '.britfixignore').write_text('color\n')
+        target = tmp_path / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' in g
+
+    def test_user_config_merged(self, tmp_path, monkeypatch):
+        """User config file is merged with project ignores."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('color\n')
+
+        user_config_dir = tmp_path / 'user_config' / 'britfix'
+        user_config_dir.mkdir(parents=True)
+        (user_config_dir / 'ignore').write_text('behavior\n')
+        monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'user_config'))
+
+        target = tmp_path / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' in g
+        assert 'behavior' in g
+
+    def test_caching_by_directory(self, tmp_path):
+        """Same directory should return cached result."""
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('color\n')
+        f1 = tmp_path / 'a.py'
+        f2 = tmp_path / 'b.py'
+        f1.touch()
+        f2.touch()
+
+        r1 = discover_ignore_words(str(f1))
+        r2 = discover_ignore_words(str(f2))
+        # Should be the exact same object (cached)
+        assert r1 is r2
+
+    def test_no_git_outside_home_stops_at_fs_root(self, tmp_path, monkeypatch):
+        """If outside home and no .git, walk up to filesystem root."""
+        # Set home to something unrelated
+        fake_home = tmp_path / 'fakehome'
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, 'home', staticmethod(lambda: fake_home))
+
+        # Create a directory outside of fake home
+        project = tmp_path / 'other' / 'project'
+        project.mkdir(parents=True)
+        (project / '.britfixignore').write_text('color\n')
+        target = project / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert 'color' in g
+
+    def test_invalid_utf8_ignore_file_skipped(self, tmp_path):
+        """Invalid UTF-8 in .britfixignore should be silently skipped."""
+        (tmp_path / '.git').mkdir()
+        # Write raw bytes that are not valid UTF-8
+        (tmp_path / '.britfixignore').write_bytes(b'\xff\xfe invalid utf8\n')
+        target = tmp_path / 'file.py'
+        target.touch()
+
+        # Should not raise, should return empty ignores
+        g, s = discover_ignore_words(str(target))
+        assert isinstance(g, set)
+        assert isinstance(s, dict)
+
+    def test_invalid_utf8_user_config_skipped(self, tmp_path, monkeypatch):
+        """Invalid UTF-8 in user config should be silently skipped."""
+        (tmp_path / '.git').mkdir()
+        user_config_dir = tmp_path / 'user_config' / 'britfix'
+        user_config_dir.mkdir(parents=True)
+        (user_config_dir / 'ignore').write_bytes(b'\x80\x81\x82\n')
+        monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'user_config'))
+
+        target = tmp_path / 'file.py'
+        target.touch()
+
+        g, s = discover_ignore_words(str(target))
+        assert isinstance(g, set)
+
+
+class TestBritfixIgnoreParsingEdgeCases:
+    """Edge cases for .britfixignore parsing."""
+
+    def test_terminal_escape_in_strategy_name_sanitized(self, capsys):
+        """Terminal escape sequences in strategy names should be escaped in warning."""
+        content = "\x1b[31mevil\x1b[0m:color\n"
+        parse_britfixignore(content)
+        captured = capsys.readouterr()
+        # The raw escape should not appear in stderr
+        assert '\x1b[' not in captured.err
+        assert 'unknown strategy' in captured.err
+
+
+class TestFilteredCorrector:
+    """Test dictionary filtering and corrector creation with ignores."""
+
+    @pytest.fixture
+    def dictionary(self):
+        return load_spelling_mappings()
+
+    def test_global_ignore(self, dictionary):
+        filtered = filter_dictionary(dictionary, {'color'}, {}, 'text')
+        assert 'color' not in filtered
+        assert 'behavior' in filtered  # Other words unaffected
+
+    def test_scoped_ignore(self, dictionary):
+        filtered = filter_dictionary(dictionary, set(), {'code': {'color'}}, 'code')
+        assert 'color' not in filtered
+        assert 'behavior' in filtered
+
+    def test_scoped_ignore_different_strategy(self, dictionary):
+        """Scoped ignore for 'code' should NOT apply to 'text'."""
+        filtered = filter_dictionary(dictionary, set(), {'code': {'color'}}, 'text')
+        assert 'color' in filtered  # Not ignored for text strategy
+
+    def test_cross_strategy_isolation(self, dictionary):
+        """Ignoring for one strategy shouldn't affect another."""
+        scoped = {'code': {'color'}, 'markdown': {'behavior'}}
+        code_filtered = filter_dictionary(dictionary, set(), scoped, 'code')
+        md_filtered = filter_dictionary(dictionary, set(), scoped, 'markdown')
+
+        assert 'color' not in code_filtered
+        assert 'behavior' in code_filtered
+        assert 'color' in md_filtered
+        assert 'behavior' not in md_filtered
+
+    def test_case_preservation_with_ignores(self, dictionary):
+        """Corrector with ignores should still preserve case for non-ignored words."""
+        corrector = get_corrector_for_strategy(dictionary, {'color'}, {}, 'text')
+        text = "The Color and Behavior are important."
+        result, changes = corrector.correct_text(text)
+        assert 'Color' in result  # Ignored, unchanged
+        assert 'Behaviour' in result  # Not ignored, converted with case
+        assert 'color' not in changes
+
+    def test_empty_ignores_returns_full_dictionary(self, dictionary):
+        filtered = filter_dictionary(dictionary, set(), {}, 'text')
+        assert filtered == dictionary
+
+    def test_corrector_caching(self, dictionary):
+        """Same inputs should return same corrector instance."""
+        from britfix_core import _corrector_cache
+        _corrector_cache.clear()
+
+        c1 = get_corrector_for_strategy(dictionary, {'color'}, {}, 'text')
+        c2 = get_corrector_for_strategy(dictionary, {'color'}, {}, 'text')
+        assert c1 is c2
+
+
+class TestIgnoreIntegration:
+    """Integration tests combining strategies with ignore support."""
+
+    @pytest.fixture
+    def dictionary(self):
+        return load_spelling_mappings()
+
+    def test_code_strategy_with_scoped_ignore(self, dictionary):
+        """CodeStrategy + scoped ignore should skip specified words in comments."""
+        corrector = get_corrector_for_strategy(
+            dictionary, set(), {'code': {'color'}}, 'code'
+        )
+        strategy = CodeStrategy()
+        code = "# The color and behavior are important"
+        result, changes = strategy.process(code, corrector)
+        assert 'color' in result  # Ignored
+        assert 'behaviour' in result  # Not ignored, converted
+
+    def test_markdown_strategy_with_global_ignore(self, dictionary):
+        """MarkdownStrategy + global ignore should skip specified words."""
+        corrector = get_corrector_for_strategy(
+            dictionary, {'color'}, {}, 'markdown'
+        )
+        strategy = MarkdownStrategy()
+        text = "The color and behavior are nice."
+        result, changes = strategy.process(text, corrector)
+        assert 'color' in result  # Ignored
+        assert 'behaviour' in result  # Converted
+
+    def test_text_strategy_scoped_code_ignore_not_applied(self, dictionary):
+        """A code-scoped ignore should NOT affect text strategy."""
+        corrector = get_corrector_for_strategy(
+            dictionary, set(), {'code': {'color'}}, 'text'
+        )
+        strategy = PlainTextStrategy()
+        text = "The color is nice."
+        result, changes = strategy.process(text, corrector)
+        assert 'colour' in result  # Not ignored for text
+
+    def test_end_to_end_file_ignore(self, tmp_path, dictionary):
+        """Full integration: .britfixignore + file processing."""
+        _ignore_cache.clear()
+
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('code:color\n')
+        py_file = tmp_path / 'test.py'
+        py_file.write_text('# The color is nice\n')
+        txt_file = tmp_path / 'test.txt'
+        txt_file.write_text('The color is nice\n')
+
+        # Python file: color should be ignored (code strategy)
+        g, s = discover_ignore_words(str(py_file))
+        py_corrector = get_corrector_for_strategy(dictionary, g, s, 'code')
+        strategy = CodeStrategy()
+        result, _ = strategy.process(py_file.read_text(), py_corrector)
+        assert 'color' in result
+        assert 'colour' not in result
+
+        # Text file: color should NOT be ignored (text strategy)
+        _ignore_cache.clear()
+        g, s = discover_ignore_words(str(txt_file))
+        txt_corrector = get_corrector_for_strategy(dictionary, g, s, 'text')
+        strategy = PlainTextStrategy()
+        result, _ = strategy.process(txt_file.read_text(), txt_corrector)
+        assert 'colour' in result
+
+
+class TestUserIgnorePath:
+    """Test get_user_ignore_path for different platforms."""
+
+    def test_unix_default(self, monkeypatch):
+        monkeypatch.setattr(os, 'name', 'posix')
+        monkeypatch.delenv('XDG_CONFIG_HOME', raising=False)
+        path = get_user_ignore_path()
+        assert path is not None
+        assert str(path).endswith('.config/britfix/ignore')
+
+    def test_unix_xdg(self, monkeypatch):
+        monkeypatch.setattr(os, 'name', 'posix')
+        monkeypatch.setenv('XDG_CONFIG_HOME', '/custom/config')
+        path = get_user_ignore_path()
+        assert path == Path('/custom/config/britfix/ignore')
+
+    @pytest.mark.skipif(os.name != 'nt', reason="WindowsPath unavailable on non-Windows")
+    def test_windows(self, monkeypatch):
+        monkeypatch.setenv('APPDATA', 'C:\\Users\\test\\AppData\\Roaming')
+        path = get_user_ignore_path()
+        assert str(path).endswith('britfix\\ignore')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `.britfixignore` file support for declaring words that should not be converted from American to British English
- Supports global exceptions (all strategies) and strategy-scoped exceptions (e.g. `code:color` only skips "color" in code files)
- Discovers ignore files by walking up from the target file to the nearest `.git` boundary, with user-level config via `~/.config/britfix/ignore`
- Merges ignore files additively (root to leaf), caches results by directory
- Handles invalid UTF-8 in ignore files gracefully and sanitises untrusted input before printing to stderr

### `.britfixignore` format
```text
# Global exceptions (all strategies)
dialog

# Strategy-scoped exceptions
code:color
code:center
markdown:dialog
```

## Files changed
- `britfix_core.py` - unified extension metadata, ignore parser, discovery, dictionary filtering, corrector caching
- `britfix.py` - CLI integration for file and stdin processing
- `test_britfix.py` - 40 new tests across 7 test classes
- `README.md` - document .britfixignore usage

## Test plan
- [x] `just test` - all 132 tests pass (1 skipped: Windows-only)
- [x] `just test-quick` - functional CLI tests pass
- [x] Manual: create `.britfixignore` with `code:color`, run on `.py` file with `# The color is nice` - should NOT convert
- [x] Manual: run on `.txt` file with `The color is nice` - should convert (scoped exception does not apply)
- [ ] Manual: run via hook - verify ignore is respected

## Out of scope (deferred)
- Making interactive mode strategy-aware (separate PR)
- Built-in default exceptions
- Inline suppression directives