### PR TITLE
Make interactive mode strategy-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ britfix --input "src/*.py" --dry-run
 ### Options
 
 - `--input`: Input file(s) or pattern(s). If omitted, reads from stdin
-- `--interactive`, `-i`: Interactive approval mode
+- `--interactive`, `-i`: Interactive approval mode (strategy-aware — only suggests changes in regions the strategy considers safe, e.g. comments in code files, prose in markdown). JSON files fall back to non-interactive processing
 - `--dry-run`: Preview changes without modifying files
 - `--no-backup`: Skip backup creation
 - `--recursive`: Process files recursively

--- a/britfix.py
+++ b/britfix.py
@@ -55,6 +55,7 @@ from britfix_core import (
     get_corrector_for_strategy,
     get_user_ignore_path,
     parse_britfixignore,
+    PlainTextStrategy,
 )
 
 
@@ -115,13 +116,13 @@ def create_backup(filepath: str) -> str:
     return backup_path
 
 
-def process_file_interactive(filepath: str, corrector: SpellingCorrector) -> tuple:
+def process_file_interactive(filepath: str, corrector: SpellingCorrector, strategy) -> tuple:
     """Process a file with enhanced interactive approval."""
     with open(filepath, 'r', encoding='utf-8') as f:
         content = f.read()
-    
-    # Find all potential replacements
-    replacements = corrector.find_replacements(content)
+
+    # Find replacements filtered by strategy segmentation rules
+    replacements = strategy.find_safe_replacements(content, corrector)
     if not replacements:
         return content, {}
     
@@ -255,8 +256,8 @@ def apply_replacements(text: str, replacements: list) -> tuple:
 
 def process_stdin_interactive(content: str, corrector: SpellingCorrector) -> tuple:
     """Process stdin content with enhanced interactive approval."""
-    # Find all potential replacements
-    replacements = corrector.find_replacements(content)
+    # Find replacements using PlainTextStrategy for consistency
+    replacements = PlainTextStrategy().find_safe_replacements(content, corrector)
     if not replacements:
         return content, {}
     
@@ -406,7 +407,13 @@ Examples:
 
             # Process the file
             if args.interactive:
-                corrected_content, file_changes = process_file_interactive(filepath, file_corrector)
+                if not strategy.supports_interactive:
+                    print(f"britfix: interactive mode not supported for this file type, processing non-interactively: {filepath}", file=sys.stderr)
+                    with open(filepath, 'r', encoding='utf-8') as f:
+                        content = f.read()
+                    corrected_content, file_changes = strategy.process(content, file_corrector)
+                else:
+                    corrected_content, file_changes = process_file_interactive(filepath, file_corrector, strategy)
             else:
                 with open(filepath, 'r', encoding='utf-8') as f:
                     content = f.read()

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -187,17 +187,27 @@ class FileProcessingStrategy:
         offset = 0
         for start, end, original, replacement in all_replacements:
             adj_start = start + offset
+            adj_end_replaced = adj_start + len(replacement)
+            # Character after the original span in the source content
+            char_after_original = content[end:end + 1]
+
+            # Check whether the replacement appears here and is followed
+            # by the same boundary as in the original content.
+            if corrected[adj_start:adj_end_replaced] == replacement:
+                char_after_candidate = corrected[adj_end_replaced:adj_end_replaced + 1]
+                if char_after_candidate == char_after_original:
+                    safe.append((start, end, original, replacement))
+                    offset += len(replacement) - len(original)
+                    continue
+
+            # If the above didn't confirm an applied replacement, check if
+            # the original text is still present unchanged at this position.
             adj_end_original = adj_start + len(original)
-            # Check for original text first — strategy left it unchanged
             if corrected[adj_start:adj_end_original] == original:
                 # Not applied by strategy, no offset change
                 continue
-            # Strategy changed this region — verify it's the expected replacement
-            adj_end_replaced = adj_start + len(replacement)
-            if corrected[adj_start:adj_end_replaced] == replacement:
-                safe.append((start, end, original, replacement))
-                offset += len(replacement) - len(original)
-            # else: unexpected state, skip conservatively
+
+            # Unexpected/misaligned state, skip conservatively
         return safe
 
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -161,10 +161,44 @@ def load_spelling_mappings(file_path: Optional[str] = None) -> Dict[str, str]:
 # File processing strategies for different file types
 class FileProcessingStrategy:
     """Base class for file processing strategies."""
-    
+
+    supports_interactive = True
+
     def process(self, content: str, corrector: SpellingCorrector) -> Tuple[str, Dict[str, int]]:
         """Process content and return corrected text with change tracking."""
         return corrector.correct_text(content)
+
+    def find_safe_replacements(self, content: str, corrector: SpellingCorrector) -> List[Tuple[int, int, str, str]]:
+        """Find replacements filtered by this strategy's segmentation rules.
+
+        Uses positional comparison between the original and strategy-processed
+        text to determine which candidates the strategy considers safe.
+
+        Note: This requires that process() preserves the structure of
+        non-corrected regions (no reformatting, normalisation, or reordering).
+        Strategies that reformat content (e.g. JSONStrategy) must not use
+        this method.
+        """
+        all_replacements = corrector.find_replacements(content)
+        if not all_replacements:
+            return []
+        corrected, _ = self.process(content, corrector)
+        safe = []
+        offset = 0
+        for start, end, original, replacement in all_replacements:
+            adj_start = start + offset
+            adj_end_original = adj_start + len(original)
+            # Check for original text first — strategy left it unchanged
+            if corrected[adj_start:adj_end_original] == original:
+                # Not applied by strategy, no offset change
+                continue
+            # Strategy changed this region — verify it's the expected replacement
+            adj_end_replaced = adj_start + len(replacement)
+            if corrected[adj_start:adj_end_replaced] == replacement:
+                safe.append((start, end, original, replacement))
+                offset += len(replacement) - len(original)
+            # else: unexpected state, skip conservatively
+        return safe
 
 
 class PlainTextStrategy(FileProcessingStrategy):
@@ -629,7 +663,9 @@ class CssStrategy(FileProcessingStrategy):
 
 class JSONStrategy(FileProcessingStrategy):
     """Process JSON files, only correcting string values."""
-    
+
+    supports_interactive = False
+
     def process(self, content: str, corrector: SpellingCorrector) -> Tuple[str, Dict[str, int]]:
         try:
             data = json.loads(content)

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -13,6 +13,7 @@ from britfix_core import (
     HTMLStrategy,
     PlainTextStrategy,
     MarkdownStrategy,
+    JSONStrategy,
     is_code_file,
     CODE_EXTENSIONS,
     parse_britfixignore,
@@ -23,6 +24,7 @@ from britfix_core import (
     get_file_strategy_name,
     _ignore_cache,
 )
+from britfix import apply_replacements
 
 
 @pytest.fixture
@@ -1281,6 +1283,116 @@ class TestUserIgnorePath:
         monkeypatch.setenv('APPDATA', 'C:\\Users\\test\\AppData\\Roaming')
         path = get_user_ignore_path()
         assert str(path).endswith('britfix\\ignore')
+
+
+class TestFindSafeReplacements:
+    """Test find_safe_replacements filters by strategy segmentation."""
+
+    @pytest.fixture
+    def corrector(self):
+        mappings = load_spelling_mappings()
+        return SpellingCorrector(mappings)
+
+    def test_code_strategy_only_comments(self, corrector):
+        """CodeStrategy: 'colour' in comment returned, in string literal not."""
+        code = '# The color is nice\nname = "color"\n'
+        strategy = CodeStrategy()
+        safe = strategy.find_safe_replacements(code, corrector)
+        originals = [r[2] for r in safe]
+        assert 'color' in originals
+        # Only one occurrence (the comment), not the string literal
+        assert len([o for o in originals if o == 'color']) == 1
+
+    def test_markdown_strategy_only_prose(self, corrector):
+        """MarkdownStrategy: 'colour' in prose returned, in code block not."""
+        md = 'The color is nice\n\n```\ncolor = value\n```\n'
+        strategy = MarkdownStrategy()
+        safe = strategy.find_safe_replacements(md, corrector)
+        originals = [r[2] for r in safe]
+        assert 'color' in originals
+        assert len([o for o in originals if o == 'color']) == 1
+
+    def test_css_strategy_only_comments(self, corrector):
+        """CssStrategy: 'colour' in comment returned, in property not."""
+        css = '/* The color is nice */\n.foo { color: red; }\n'
+        strategy = CssStrategy()
+        safe = strategy.find_safe_replacements(css, corrector)
+        originals = [r[2] for r in safe]
+        assert 'color' in originals
+        assert len([o for o in originals if o == 'color']) == 1
+
+    def test_html_strategy_only_text(self, corrector):
+        """HTMLStrategy: 'colour' in text returned, in script not."""
+        html = '<p>The color is nice</p>\n<script>var color = 1;</script>\n'
+        strategy = HTMLStrategy()
+        safe = strategy.find_safe_replacements(html, corrector)
+        originals = [r[2] for r in safe]
+        assert 'color' in originals
+        assert len([o for o in originals if o == 'color']) == 1
+
+    def test_plain_text_all_returned(self, corrector):
+        """PlainTextStrategy: all occurrences returned."""
+        text = 'The color is nice. Another color here.'
+        strategy = PlainTextStrategy()
+        safe = strategy.find_safe_replacements(text, corrector)
+        originals = [r[2] for r in safe]
+        assert originals.count('color') == 2
+
+    def test_code_strategy_shorter_replacement(self, corrector):
+        """CodeStrategy: shorter replacement (appall->appal) only in comment."""
+        code = '# appall\nname = "appall"\n'
+        strategy = CodeStrategy()
+        safe = strategy.find_safe_replacements(code, corrector)
+        originals = [r[2] for r in safe]
+        assert originals == ['appall']
+        # Verify it's from the comment (position 2), not the string literal
+        assert safe[0][0] == 2
+
+    def test_code_strategy_shorter_replacement_distill(self, corrector):
+        """CodeStrategy: distill->distil only in comment, not string."""
+        code = '# distill\nname = "distill"\n'
+        strategy = CodeStrategy()
+        safe = strategy.find_safe_replacements(code, corrector)
+        assert len(safe) == 1
+        assert safe[0][2] == 'distill'
+
+
+class TestInteractiveStrategyInvariant:
+    """Approve-all via find_safe_replacements + apply_replacements should equal process()."""
+
+    @pytest.fixture
+    def corrector(self):
+        mappings = load_spelling_mappings()
+        return SpellingCorrector(mappings)
+
+    @pytest.mark.parametrize("strategy,content", [
+        (CodeStrategy(), '# The color and behavior\nname = "color"\n'),
+        (CodeStrategy(), '# appall and distill\nname = "appall"\n'),
+        (MarkdownStrategy(), 'The color is nice\n\n```\ncolor = x\n```\n'),
+        (CssStrategy(), '/* color behavior */\n.x { color: red; }\n'),
+        (HTMLStrategy(), '<p>color behavior</p><script>var color=1;</script>'),
+        (PlainTextStrategy(), 'The color and behavior are analyzed.'),
+        (PlainTextStrategy(), 'appall and distill and fulfill'),
+    ])
+    def test_approve_all_equals_process(self, corrector, strategy, content):
+        safe = strategy.find_safe_replacements(content, corrector)
+        result_interactive, _ = apply_replacements(content, safe)
+        result_process, _ = strategy.process(content, corrector)
+        assert result_interactive == result_process
+
+
+class TestJsonInteractiveFallback:
+    """JSON files in interactive mode fall back to non-interactive processing."""
+
+    def test_json_not_supports_interactive(self):
+        """JSONStrategy has supports_interactive=False."""
+        strategy = JSONStrategy()
+        assert not strategy.supports_interactive
+
+    def test_other_strategies_support_interactive(self):
+        """Non-JSON strategies have supports_interactive=True."""
+        for strategy_cls in [PlainTextStrategy, MarkdownStrategy, CodeStrategy, CssStrategy, HTMLStrategy]:
+            assert strategy_cls().supports_interactive
 
 
 if __name__ == "__main__":

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1356,6 +1356,23 @@ class TestFindSafeReplacements:
         assert len(safe) == 1
         assert safe[0][2] == 'distill'
 
+    def test_code_strategy_longer_replacement_catalog(self, corrector):
+        """CodeStrategy: longer replacement (catalog->catalogue) only in comment."""
+        code = '# catalog\nname = "catalog"\n'
+        strategy = CodeStrategy()
+        safe = strategy.find_safe_replacements(code, corrector)
+        originals = [r[2] for r in safe]
+        assert originals == ['catalog']
+        assert safe[0][0] == 2
+
+    def test_code_strategy_longer_replacement_program(self, corrector):
+        """CodeStrategy: program->programme only in comment, not string."""
+        code = '# program\nname = "program"\n'
+        strategy = CodeStrategy()
+        safe = strategy.find_safe_replacements(code, corrector)
+        assert len(safe) == 1
+        assert safe[0][2] == 'program'
+
 
 class TestInteractiveStrategyInvariant:
     """Approve-all via find_safe_replacements + apply_replacements should equal process()."""
@@ -1368,6 +1385,7 @@ class TestInteractiveStrategyInvariant:
     @pytest.mark.parametrize("strategy,content", [
         (CodeStrategy(), '# The color and behavior\nname = "color"\n'),
         (CodeStrategy(), '# appall and distill\nname = "appall"\n'),
+        (CodeStrategy(), '# catalog and program\nname = "catalog"\n'),
         (MarkdownStrategy(), 'The color is nice\n\n```\ncolor = x\n```\n'),
         (CssStrategy(), '/* color behavior */\n.x { color: red; }\n'),
         (HTMLStrategy(), '<p>color behavior</p><script>var color=1;</script>'),


### PR DESCRIPTION
## Summary

- Interactive mode (`--interactive`) now respects file-type strategies — it only suggests changes in regions the strategy considers safe (comments in code, prose in markdown, etc.)
- Previously it bypassed strategies entirely, suggesting changes inside code strings, markdown code blocks, CSS properties, etc.
- JSON files fall back to non-interactive processing with a stderr warning, since `JSONStrategy` reformats content via `json.dumps`

## Implementation

- Added `find_safe_replacements()` to `FileProcessingStrategy` base class — runs `process()` once, then uses positional comparison to determine which candidates were actually applied
- Added `supports_interactive` flag to the strategy API (`False` for `JSONStrategy`) so the contract is enforced rather than relying on `isinstance` checks
- Fixed a correctness bug in the positional algorithm where shorter replacements (e.g. `appall`→`appal`) could falsely match in excluded regions

## Test plan

- [x] `TestFindSafeReplacements` — per-strategy filtering (Code, Markdown, CSS, HTML, PlainText) including shorter-replacement edge cases
- [x] `TestInteractiveStrategyInvariant` — parameterised: approve-all via `find_safe_replacements` + `apply_replacements` equals `strategy.process()` for all non-JSON strategies
- [x] `TestJsonInteractiveFallback` — verifies `supports_interactive` flag
- [x] All 148 tests pass

## Related issues

- #7 — pre-existing: JSONStrategy falls back to raw `correct_text()` on malformed JSON
- #8 — pre-existing: interactive word grouping is O(n²) and duplicated