### PR TITLE
Add trailing * wildcard support in .britfixignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,19 @@ Create a `.britfixignore` file to prevent specific words from being converted. T
 # Global exceptions (all strategies)
 dialog
 
+# Wildcard — ignores 'dialog', 'dialogs', and any other dictionary
+# entry starting with 'dialog'
+dialog*
+
 # Strategy-scoped exceptions (only apply to that file type)
 code:color
-code:center
+code:center*
 markdown:dialog
 ```
 
 - One word per line, `#` comments, blank lines skipped
 - Optional `strategy:` prefix scopes the exception to that strategy only
+- A trailing `*` acts as a prefix wildcard, ignoring the base word and all its inflected/compound forms in the dictionary (e.g. `color*` ignores `color`, `colors`, `colored`, `colorful`, `colorize`, etc.)
 - Words use American (source) spelling (e.g. `color` not `colour`)
 - Case-insensitive
 
@@ -117,19 +122,23 @@ A personal ignore file applies to all projects:
 
 With this `.britfixignore` at your project root:
 ```text
-code:color
+dialog*
+code:color*
 code:center
 ```
 
 Running britfix on a Python file:
 ```python
-# The color is nice   ->  unchanged (code:color exception)
+# The color is nice   ->  unchanged (code:color* exception)
+# The dialogs work    ->  unchanged (global dialog* exception)
 # The behavior is ok  ->  # The behaviour is ok (not excepted)
 ```
 
-Running britfix on a text file:
+Running britfix on a Markdown file:
 ```text
-The color is nice  ->  The colour is nice (exception is code-scoped, doesn't apply)
+The color is nice   ->  The colour is nice (color* is code-scoped, doesn't apply)
+Open the dialog     ->  unchanged (global dialog* exception)
+Open the dialogs    ->  unchanged (global dialog* wildcard covers inflected forms)
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ markdown:dialog
 - One word per line, `#` comments, blank lines skipped
 - Optional `strategy:` prefix scopes the exception to that strategy only
 - A trailing `*` acts as a prefix wildcard, ignoring the base word and all its inflected/compound forms in the dictionary (e.g. `color*` ignores `color`, `colors`, `colored`, `colorful`, `colorize`, etc.)
+- A bare `*` entry is invalid and ignored; it does not match anything or act as "ignore everything"
 - Words use American (source) spelling (e.g. `color` not `colour`)
 - Case-insensitive
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -1124,24 +1124,23 @@ def _expand_ignores(ignored: Set[str], dictionary: Dict[str, str]) -> Set[str]:
     if not ignored:
         return ignored
     exact: Set[str] = set()
-    prefixes: List[str] = []
+    prefixes: Set[str] = set()
     for word in ignored:
         lowered = word.lower()
         if lowered.endswith('*'):
             prefix = lowered[:-1]
             if prefix:  # reject bare '*'
-                prefixes.append(prefix)
+                prefixes.add(prefix)
         else:
             exact.add(lowered)
     if not prefixes:
         return exact
     expanded = set(exact)
+    prefix_tuple = tuple(prefixes)
     for key in dictionary:
         k_lower = key.lower()
-        for prefix in prefixes:
-            if k_lower.startswith(prefix):
-                expanded.add(k_lower)
-                break
+        if k_lower.startswith(prefix_tuple):
+            expanded.add(k_lower)
     return expanded
 
 
@@ -1166,6 +1165,8 @@ def filter_dictionary(
         return dictionary
 
     expanded = _expand_ignores(all_ignored, dictionary)
+    if not expanded:
+        return dictionary
     return {k: v for k, v in dictionary.items() if k.lower() not in expanded}
 
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -1113,6 +1113,38 @@ def discover_ignore_words(file_path: str) -> Tuple[Set[str], Dict[str, Set[str]]
     return result
 
 
+def _expand_ignores(ignored: Set[str], dictionary: Dict[str, str]) -> Set[str]:
+    """Expand wildcard ignore patterns against dictionary keys.
+
+    Plain words match exactly.  A trailing ``*`` matches the word prefix against
+    all dictionary keys (e.g. ``dialog*`` matches ``dialog`` and ``dialogs``).
+    All inputs are normalised to lowercase.  A bare ``*`` (empty prefix) is
+    silently dropped to avoid disabling all corrections.
+    """
+    if not ignored:
+        return ignored
+    exact: Set[str] = set()
+    prefixes: List[str] = []
+    for word in ignored:
+        lowered = word.lower()
+        if lowered.endswith('*'):
+            prefix = lowered[:-1]
+            if prefix:  # reject bare '*'
+                prefixes.append(prefix)
+        else:
+            exact.add(lowered)
+    if not prefixes:
+        return exact
+    expanded = set(exact)
+    for key in dictionary:
+        k_lower = key.lower()
+        for prefix in prefixes:
+            if k_lower.startswith(prefix):
+                expanded.add(k_lower)
+                break
+    return expanded
+
+
 def filter_dictionary(
     dictionary: Dict[str, str],
     global_ignores: Set[str],
@@ -1123,6 +1155,9 @@ def filter_dictionary(
 
     global_ignores apply to all strategies. scoped_ignores[strategy_name]
     applies only to the given strategy. Words are matched case-insensitively.
+    A trailing ``*`` acts as a prefix wildcard (e.g. ``dialog*`` ignores
+    ``dialog``, ``dialogs``, and any other dictionary entry starting with
+    ``dialog``).
     """
     strategy_ignores = scoped_ignores.get(strategy_name, set())
     all_ignored = global_ignores | strategy_ignores
@@ -1130,7 +1165,8 @@ def filter_dictionary(
     if not all_ignored:
         return dictionary
 
-    return {k: v for k, v in dictionary.items() if k.lower() not in all_ignored}
+    expanded = _expand_ignores(all_ignored, dictionary)
+    return {k: v for k, v in dictionary.items() if k.lower() not in expanded}
 
 
 # Cache for correctors keyed by (dict_id, strategy_name, frozenset(ignored)).

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -23,6 +23,7 @@ from britfix_core import (
     get_corrector_for_strategy,
     get_file_strategy_name,
     _ignore_cache,
+    _corrector_cache,
 )
 from britfix import apply_replacements
 
@@ -1260,6 +1261,89 @@ class TestIgnoreIntegration:
         strategy = PlainTextStrategy()
         result, _ = strategy.process(txt_file.read_text(), txt_corrector)
         assert 'colour' in result
+
+
+class TestWildcardIgnore:
+    """Test trailing * wildcard in .britfixignore entries."""
+
+    @pytest.fixture
+    def dictionary(self):
+        return load_spelling_mappings()
+
+    def test_wildcard_expands_to_inflected_forms(self, dictionary):
+        """dialog* should ignore both 'dialog' and 'dialogs'."""
+        filtered = filter_dictionary(dictionary, {'dialog*'}, {}, 'text')
+        assert 'dialog' not in filtered
+        assert 'dialogs' not in filtered
+        assert 'behavior' in filtered  # Unrelated word unaffected
+
+    def test_exact_word_does_not_expand(self, dictionary):
+        """Plain 'dialog' (no *) should only ignore the exact word."""
+        filtered = filter_dictionary(dictionary, {'dialog'}, {}, 'text')
+        assert 'dialog' not in filtered
+        assert 'dialogs' in filtered  # Plural NOT ignored
+
+    def test_wildcard_color_family(self, dictionary):
+        """color* should ignore color, colors, colored, colorful, etc."""
+        filtered = filter_dictionary(dictionary, {'color*'}, {}, 'text')
+        for key in list(dictionary.keys()):
+            if key.lower().startswith('color'):
+                assert key not in filtered, f"'{key}' should be filtered by color*"
+        assert 'behavior' in filtered
+
+    def test_wildcard_in_scoped_ignore(self, dictionary):
+        """Wildcards should work in strategy-scoped ignores too."""
+        filtered = filter_dictionary(dictionary, set(), {'code': {'dialog*'}}, 'code')
+        assert 'dialog' not in filtered
+        assert 'dialogs' not in filtered
+
+    def test_wildcard_scoped_does_not_leak(self, dictionary):
+        """Wildcard scoped to 'code' should not affect 'text'."""
+        filtered = filter_dictionary(dictionary, set(), {'code': {'dialog*'}}, 'text')
+        assert 'dialog' in filtered
+        assert 'dialogs' in filtered
+
+    def test_parse_preserves_wildcard(self):
+        """parse_britfixignore should keep trailing * in words."""
+        content = "dialog*\ncode:color*\n"
+        global_ig, scoped_ig = parse_britfixignore(content)
+        assert 'dialog*' in global_ig
+        assert 'color*' in scoped_ig.get('code', set())
+
+    def test_mixed_case_wildcard(self, dictionary):
+        """Wildcard matching should be case-insensitive."""
+        filtered = filter_dictionary(dictionary, {'Dialog*'}, {}, 'text')
+        assert 'dialog' not in filtered
+        assert 'dialogs' not in filtered
+
+    def test_mixed_case_exact(self, dictionary):
+        """Exact matching should be case-insensitive."""
+        filtered = filter_dictionary(dictionary, {'Dialog'}, {}, 'text')
+        assert 'dialog' not in filtered
+
+    def test_bare_star_does_not_disable_all(self, dictionary):
+        """A bare '*' should be silently dropped, not disable all corrections."""
+        filtered = filter_dictionary(dictionary, {'*'}, {}, 'text')
+        assert len(filtered) == len(dictionary)
+
+    def test_end_to_end_wildcard_ignore(self, tmp_path, dictionary):
+        """Full integration: wildcard in .britfixignore file."""
+        _ignore_cache.clear()
+        _corrector_cache.clear()
+
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('dialog*\n')
+        md_file = tmp_path / 'test.md'
+        md_file.write_text('The dialog and dialogs are shown.\n')
+
+        g, s = discover_ignore_words(str(md_file))
+        corrector = get_corrector_for_strategy(dictionary, g, s, 'markdown')
+        strategy = MarkdownStrategy()
+        result, changes = strategy.process(md_file.read_text(), corrector)
+        assert 'dialogue' not in result
+        assert 'dialogues' not in result
+        assert 'dialog' in result
+        assert 'dialogs' in result
 
 
 class TestUserIgnorePath:


### PR DESCRIPTION
## Summary
- Adds trailing `*` wildcard syntax to `.britfixignore` entries, so `dialog*` ignores `dialog`, `dialogs`, and all other dictionary entries starting with `dialog`
- Without `*`, behaviour is unchanged — only the exact word is ignored
- Includes case-insensitive normalisation and rejects bare `*` to prevent silently disabling all corrections

## Test plan
- [x] 10 new tests in `TestWildcardIgnore` covering wildcard expansion, exact-match preservation, scoped wildcards, case-insensitivity, bare `*` rejection, and end-to-end integration
- [x] All 161 tests pass (151 existing + 10 new)
- [ ] Manual test: add `dialog*` to a project `.britfixignore` and verify both `dialog` and `dialogs` are preserved