### PR TITLE
Preserve blockquote lines in markdown strategy

### DIFF
--- a/britfix_core.py
+++ b/britfix_core.py
@@ -266,6 +266,17 @@ class MarkdownStrategy(FileProcessingStrategy):
 
         return -1
 
+    def _line_is_blockquote(self, content: str, line_start: int) -> bool:
+        """
+        Check if the line beginning at line_start is a blockquote line.
+        A blockquote line starts with > after up to 3 spaces of indentation.
+        4+ spaces is an indented code block, not a blockquote.
+        """
+        indent = 0
+        while indent < 3 and line_start + indent < len(content) and content[line_start + indent] == ' ':
+            indent += 1
+        return line_start + indent < len(content) and content[line_start + indent] == '>'
+
     def _find_indented_block_end(self, content: str, start: int) -> int:
         """
         Find end of indented code block (4 spaces or 1 tab).
@@ -345,6 +356,17 @@ class MarkdownStrategy(FileProcessingStrategy):
                     i = block_end
                     continue
 
+            # Check for blockquote lines (> after up to 3 spaces of indent)
+            # Preserve the entire line unchanged — quoted text should be verbatim.
+            if self._is_at_line_start(content, i) and self._line_is_blockquote(content, i):
+                line_end = content.find('\n', i)
+                if line_end == -1:
+                    result.append(content[i:])
+                    break
+                result.append(content[i:line_end + 1])
+                i = line_end + 1
+                continue
+
             # Check for inline code spans (backticks)
             if content[i] == '`':
                 # Count consecutive backticks
@@ -380,15 +402,19 @@ class MarkdownStrategy(FileProcessingStrategy):
                 next_code = min(next_code, tilde_pos)
 
             # Look for potential indented code block (newline followed by 4 spaces or tab)
+            # or blockquote line (newline followed by optional spaces then >)
             pos = i
             while pos < next_code:
                 newline_pos = content.find('\n', pos)
                 if newline_pos == -1 or newline_pos >= next_code:
                     break
-                # Check if next line starts with indent
+                # Check if next line starts with indent or is a blockquote
                 next_char_pos = newline_pos + 1
                 if next_char_pos < len(content):
                     if content[next_char_pos:next_char_pos + 4] == '    ' or content[next_char_pos] == '\t':
+                        next_code = min(next_code, next_char_pos)
+                        break
+                    if self._line_is_blockquote(content, next_char_pos):
                         next_code = min(next_code, next_char_pos)
                         break
                 pos = newline_pos + 1

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -393,13 +393,21 @@ class MarkdownStrategy(FileProcessingStrategy):
                         break
                 pos = newline_pos + 1
 
-            # Process text up to next code delimiter
+            # Process text up to next code delimiter, skipping HTML tags
             segment = content[i:next_code]
             if segment:
-                corrected, changes = corrector.correct_text(segment)
-                result.append(corrected)
-                for word, count in changes.items():
-                    total_changes[word] += count
+                # Split on HTML tags so attribute values aren't corrected
+                # Require tag-like structure: < then letter or / to avoid matching bare < in prose
+                tag_pattern = r'(</?[a-zA-Z][^>]*>)'
+                parts = re.split(tag_pattern, segment)
+                for idx, part in enumerate(parts):
+                    if idx % 2 == 0:  # Text outside tags
+                        corrected, changes = corrector.correct_text(part)
+                        result.append(corrected)
+                        for word, count in changes.items():
+                            total_changes[word] += count
+                    else:  # HTML tag — preserve unchanged
+                        result.append(part)
 
             # If we're at a delimiter that wasn't handled as a code block
             # (e.g., tilde not at line start like "~7 days"), just add it and advance

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -395,6 +395,90 @@ Normal color text."""
         assert "~7" in result
         assert "analysed" in result
 
+    # === BLOCKQUOTES ===
+
+    def test_blockquote_line_preserved(self, strategy, corrector):
+        """A single blockquote line should be preserved verbatim (quoted text is verbatim)."""
+        text = '> "The organization analyzed its color scheme."'
+        result, changes = strategy.process(text, corrector)
+        assert result == text, f"Blockquote was modified: {result}"
+
+    def test_blockquote_preserved_prose_converted(self, strategy, corrector):
+        """Prose around a blockquote should be converted; blockquote itself should not."""
+        text = """Before the color.
+
+> "The organization analyzed its color scheme."
+
+After the color."""
+        result, changes = strategy.process(text, corrector)
+        assert '> "The organization analyzed its color scheme."' in result
+        assert "Before the colour." in result
+        assert "After the colour." in result
+
+    def test_multiline_blockquote_preserved(self, strategy, corrector):
+        """Multi-line blockquotes should preserve every line."""
+        text = """Prose with color.
+
+> "First line with organization.
+> Second line with behavior.
+> Third line with favorite."
+
+More color prose."""
+        result, changes = strategy.process(text, corrector)
+        assert "> \"First line with organization." in result
+        assert "> Second line with behavior." in result
+        assert "> Third line with favorite.\"" in result
+        assert "with colour" in result
+        assert "More colour prose." in result
+
+    def test_blockquote_with_leading_spaces_preserved(self, strategy, corrector):
+        """Blockquotes with up to 3 leading spaces should still be preserved."""
+        text = """Prose color.
+
+   > "Indented quote with organization."
+
+More color."""
+        result, changes = strategy.process(text, corrector)
+        assert '   > "Indented quote with organization."' in result
+        assert "Prose colour." in result
+        assert "More colour." in result
+
+    def test_four_space_indent_is_code_not_blockquote(self, strategy, corrector):
+        """4+ leading spaces should be treated as indented code block, not blockquote."""
+        text = """Prose color.
+
+    > "This is indented code, not a blockquote with organization."
+
+More color."""
+        result, changes = strategy.process(text, corrector)
+        # 4 spaces makes this an indented code block — preserved anyway, so organization stays
+        assert "organization" in result
+        assert "Prose colour." in result
+        assert "More colour." in result
+
+    def test_greater_than_in_prose_not_treated_as_blockquote(self, strategy, corrector):
+        """A > mid-line should not trigger blockquote preservation."""
+        text = "If color > organization, analyze the behavior."
+        result, changes = strategy.process(text, corrector)
+        assert "colour" in result
+        assert "organisation" in result
+        assert "analyse" in result
+        assert "behaviour" in result
+
+    def test_blockquote_at_start_of_file(self, strategy, corrector):
+        """A blockquote as the very first line should be preserved."""
+        text = '> "Opening quote with organization."\n\nFollowing color prose.'
+        result, changes = strategy.process(text, corrector)
+        assert '> "Opening quote with organization."' in result
+        assert "Following colour prose." in result
+
+    def test_blockquote_at_end_of_file_no_trailing_newline(self, strategy, corrector):
+        """A blockquote at the very end of the file (no trailing newline) should be preserved."""
+        text = 'Leading color prose.\n\n> "Closing quote with organization."'
+        result, changes = strategy.process(text, corrector)
+        assert '> "Closing quote with organization."' in result
+        assert "Leading colour prose." in result
+
 
 class TestMarkdownStrategyMapping:
     """Test that markdown file extensions map to MarkdownStrategy."""


### PR DESCRIPTION
## Summary
- `MarkdownStrategy` now preserves blockquote lines (lines starting with `>` after 0-3 spaces of indent) verbatim, matching how fenced code blocks, indented code blocks, and inline code spans are already handled.
- Motivation: blockquotes in markdown typically represent quoted text that should be reproduced exactly. Peer review comments quoting a manuscript, documentation quoting RFCs or specs, and similar cases all rely on verbatim reproduction, and converting spelling inside a quotation silently misrepresents the source.

## Implementation
- New `MarkdownStrategy._line_is_blockquote()` helper. 0-3 space indent then `>` is a blockquote; 4+ spaces is an indented code block per CommonMark.
- The main loop preserves whole blockquote lines when encountered at line start.
- The "find next delimiter" scan now also stops at upcoming blockquote lines, so prose processing doesn't reach into them.

## Stacking note
This PR is based on #11 (HTML tag preservation), since both touch `MarkdownStrategy.process()` and would otherwise conflict. If #11 merges first, this rebases cleanly onto `main`. Happy to flatten into a single PR if that's easier to review.

## Test plan
- [x] 8 new tests in `TestMarkdownStrategy`: single-line blockquote, multi-line, prose around blockquote, leading spaces (up to 3), 4-space indent treated as code, mid-line `>` in prose, start-of-file blockquote, end-of-file blockquote without trailing newline.
- [x] Full suite: 169 passed, 1 skipped on this branch. All pre-existing tests unaffected.