### PR TITLE
Group security updates and tune version grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     groups:
-      minor-and-patch:
+      all-version:
+        applies-to: version-updates
         patterns: ["*"]
-        update-types: ["minor", "patch"]
+      security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
Switches to full grouping: one PR per ecosystem for all version updates (minor+patch+major) and a separate grouped PR for security advisories.