### PR TITLE
Add CI + auto-merge + Claude review workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,12 @@
+name: Auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    uses: Talieisin/.github/.github/workflows/auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    uses: Talieisin/.github/.github/workflows/ci-uv.yml@main
+    secrets: inherit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,10 @@
+name: Claude review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    uses: Talieisin/.github/.github/workflows/claude-review.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds three reusable-workflow callers: CI (build/test), Claude review (non-bot PRs), Dependabot auto-merge. All reuse workflows from Talieisin/.github.