### PR TITLE
Claude review: scope to humans + Dependabot majors

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,7 +4,33 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
+  decide:
+    runs-on: ubuntu-latest
+    outputs:
+      should-review: ${{ steps.out.outputs.result }}
+    steps:
+      - name: Fetch Dependabot metadata (only for bot PRs)
+        id: meta
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Decide whether to review
+        id: out
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+        run: |
+          if [ "$AUTHOR" != "dependabot[bot]" ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          elif [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
+
   review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    needs: decide
+    if: needs.decide.outputs.should-review == 'true'
     uses: Talieisin/.github/.github/workflows/claude-review.yml@main
     secrets: inherit


### PR DESCRIPTION
Replaces the blanket skip with a decision step: Claude review runs for (a) non-bot PRs, and (b) Dependabot PRs with update-type semver-major. Dependabot minor/patch/security auto-merge without review, saving quota.