### PR TITLE
Fix JSONStrategy silently corrupting malformed JSON (#7)

### DIFF
--- a/britfix_core.py
+++ b/britfix_core.py
@@ -742,7 +742,7 @@ class JSONStrategy(FileProcessingStrategy):
                 file=sys.stderr,
             )
             return content, {}
-    
+
     def _process_json_value(self, value, corrector: SpellingCorrector, change_tracker: defaultdict):
         """Recursively process JSON values."""
         if isinstance(value, dict):

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -736,9 +736,12 @@ class JSONStrategy(FileProcessingStrategy):
             total_changes = defaultdict(int)
             self._process_json_value(data, corrector, total_changes)
             return json.dumps(data, indent=2, ensure_ascii=False), dict(total_changes)
-        except json.JSONDecodeError:
-            # Fall back to plain text processing
-            return corrector.correct_text(content)
+        except json.JSONDecodeError as e:
+            print(
+                f"britfix: skipping malformed JSON ({e.msg} at line {e.lineno}, column {e.colno})",
+                file=sys.stderr,
+            )
+            return content, {}
     
     def _process_json_value(self, value, corrector: SpellingCorrector, change_tracker: defaultdict):
         """Recursively process JSON values."""

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1630,5 +1630,34 @@ class TestJsonInteractiveFallback:
             assert strategy_cls().supports_interactive
 
 
+class TestJSONStrategyMalformed:
+    """Malformed JSON must be left untouched, with a stderr warning."""
+
+    def test_malformed_json_left_unchanged(self, corrector, capsys):
+        # Trailing comma makes this invalid JSON; contains American spellings
+        # in both keys and values that the old fallback would have rewritten.
+        content = '{\n  "color": "organized",\n  "behavior": 1,\n}\n'
+        strategy = JSONStrategy()
+        result, changes = strategy.process(content, corrector)
+        assert result == content
+        assert changes == {}
+
+    def test_malformed_json_emits_stderr_warning(self, corrector, capsys):
+        content = '{ not valid json'
+        strategy = JSONStrategy()
+        strategy.process(content, corrector)
+        captured = capsys.readouterr()
+        assert "britfix: skipping malformed JSON" in captured.err
+
+    def test_valid_json_still_processed(self, corrector):
+        # Sanity check that the happy path is intact after the fallback removal.
+        content = '{"description": "The color was analyzed"}'
+        strategy = JSONStrategy()
+        result, changes = strategy.process(content, corrector)
+        assert "colour" in result
+        assert "analysed" in result
+        assert "color" in changes
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1633,7 +1633,7 @@ class TestJsonInteractiveFallback:
 class TestJSONStrategyMalformed:
     """Malformed JSON must be left untouched, with a stderr warning."""
 
-    def test_malformed_json_left_unchanged(self, corrector, capsys):
+    def test_malformed_json_left_unchanged(self, corrector):
         # Trailing comma makes this invalid JSON; contains American spellings
         # in both keys and values that the old fallback would have rewritten.
         content = '{\n  "color": "organized",\n  "behavior": 1,\n}\n'


### PR DESCRIPTION
## Summary

- `JSONStrategy.process()` previously caught `json.JSONDecodeError` and fell back to `corrector.correct_text(content)`, which rewrites the entire file (including JSON keys and syntax) as plain text. A file like `{"appall": 1}` that failed to parse could be silently rewritten to `{"appal": 1}`.
- Replaced the fallback with a stderr warning naming the parse error location, and return the content unchanged with no recorded changes.
- Rationale: a JSON strategy that silently rewrites non-JSON is worse than a no-op. No new flag is added — this is a bug fix, not a feature toggle.

Fixes #7.

## Test plan

- [x] New `TestJSONStrategyMalformed` class covers:
  - Malformed JSON containing American spellings in keys/values is left unchanged.
  - A stderr warning containing `britfix: skipping malformed JSON` is emitted.
  - Valid JSON happy-path is unaffected (regression guard).
- [x] Full pytest suite green (178 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)