### PR TITLE
Add 'strategy:*' escape hatch to .britfixignore (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,17 @@ dialog*
 code:color
 code:center*
 markdown:dialog
+
+# Disable an entire strategy (escape hatch — equivalent to "ignore every
+# word in JSON files")
+json:*
 ```
 
 - One word per line, `#` comments, blank lines skipped
 - Optional `strategy:` prefix scopes the exception to that strategy only
 - A trailing `*` acts as a prefix wildcard, ignoring the base word and all its inflected/compound forms in the dictionary (e.g. `color*` ignores `color`, `colors`, `colored`, `colorful`, `colorize`, etc.)
-- A bare `*` entry is invalid and ignored; it does not match anything or act as "ignore everything"
+- A scoped bare `*` (e.g. `json:*`) disables that strategy entirely. Useful when a strategy is too broad for your project and you want to opt out without enumerating every word.
+- A global bare `*` is invalid and ignored; it does not match anything or act as "ignore everything"
 - Words use American (source) spelling (e.g. `color` not `colour`)
 - Case-insensitive
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -1167,26 +1167,40 @@ def discover_ignore_words(file_path: str) -> Tuple[Set[str], Dict[str, Set[str]]
     return result
 
 
-def _expand_ignores(ignored: Set[str], dictionary: Dict[str, str]) -> Set[str]:
+def _expand_ignores(
+    ignored: Set[str],
+    dictionary: Dict[str, str],
+    allow_bare_wildcard: bool = False,
+) -> Set[str]:
     """Expand wildcard ignore patterns against dictionary keys.
 
     Plain words match exactly.  A trailing ``*`` matches the word prefix against
     all dictionary keys (e.g. ``dialog*`` matches ``dialog`` and ``dialogs``).
-    All inputs are normalised to lowercase.  A bare ``*`` (empty prefix) is
-    silently dropped to avoid disabling all corrections.
+    All inputs are normalised to lowercase.
+
+    A bare ``*`` (empty prefix) is silently dropped by default to avoid
+    disabling all corrections.  When ``allow_bare_wildcard`` is True, a bare
+    ``*`` expands to every dictionary key — used for strategy-scoped escape
+    hatches like ``json:*`` that disable an entire strategy.
     """
     if not ignored:
         return ignored
     exact: Set[str] = set()
     prefixes: Set[str] = set()
+    bare_wildcard = False
     for word in ignored:
         lowered = word.lower()
         if lowered.endswith('*'):
             prefix = lowered[:-1]
-            if prefix:  # reject bare '*'
+            if prefix:
                 prefixes.add(prefix)
+            elif allow_bare_wildcard:
+                bare_wildcard = True
+            # else: bare '*' silently dropped
         else:
             exact.add(lowered)
+    if bare_wildcard:
+        return {k.lower() for k in dictionary}
     if not prefixes:
         return exact
     expanded = set(exact)
@@ -1211,14 +1225,19 @@ def filter_dictionary(
     A trailing ``*`` acts as a prefix wildcard (e.g. ``dialog*`` ignores
     ``dialog``, ``dialogs``, and any other dictionary entry starting with
     ``dialog``).
+
+    A bare ``*`` is allowed only as a strategy-scoped entry (``json:*``)
+    where it disables the entire strategy. As a global entry it is silently
+    dropped, since it would suppress all corrections everywhere.
     """
     strategy_ignores = scoped_ignores.get(strategy_name, set())
-    all_ignored = global_ignores | strategy_ignores
 
-    if not all_ignored:
+    if not global_ignores and not strategy_ignores:
         return dictionary
 
-    expanded = _expand_ignores(all_ignored, dictionary)
+    expanded_global = _expand_ignores(global_ignores, dictionary, allow_bare_wildcard=False)
+    expanded_scoped = _expand_ignores(strategy_ignores, dictionary, allow_bare_wildcard=True)
+    expanded = expanded_global | expanded_scoped
     if not expanded:
         return dictionary
     return {k: v for k, v in dictionary.items() if k.lower() not in expanded}

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -1243,10 +1243,14 @@ def filter_dictionary(
     return {k: v for k, v in dictionary.items() if k.lower() not in expanded}
 
 
-# Cache for correctors keyed by (dict_id, strategy_name, frozenset(ignored)).
+# Cache for correctors keyed by (dict_id, strategy_name, frozenset(global), frozenset(scoped)).
 # Uses id() for the dictionary — safe because the dictionary object is kept alive
 # for the entire CLI run, so the id cannot be reused by a different object.
-_corrector_cache: Dict[Tuple[int, str, frozenset], SpellingCorrector] = {}
+# Global and scoped ignores are kept as separate frozensets in the key so that
+# wildcard tokens like ``*`` (which have different semantics in each scope —
+# global ``*`` is dropped, scoped ``json:*`` disables a strategy) cannot
+# collide in the cache.
+_corrector_cache: Dict[Tuple[int, str, frozenset, frozenset], SpellingCorrector] = {}
 
 
 def get_corrector_for_strategy(
@@ -1257,9 +1261,13 @@ def get_corrector_for_strategy(
 ) -> SpellingCorrector:
     """Get a (cached) SpellingCorrector with ignored words filtered out."""
     strategy_ignores = scoped_ignores.get(strategy_name, set())
-    effective_ignored = frozenset(global_ignores | strategy_ignores)
 
-    cache_key = (id(base_dictionary), strategy_name, effective_ignored)
+    cache_key = (
+        id(base_dictionary),
+        strategy_name,
+        frozenset(global_ignores),
+        frozenset(strategy_ignores),
+    )
     if cache_key in _corrector_cache:
         return _corrector_cache[cache_key]
 

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1470,7 +1470,7 @@ class TestWildcardIgnore:
         assert len(filtered) == len(dictionary)
 
     def test_scoped_bare_star_combined_with_other_scoped_words(self, dictionary):
-        """'json:*' alongside 'markdown:foo' only zeroes out the JSON strategy."""
+        """'json:*' alongside 'markdown:dialog' only zeroes out the JSON strategy."""
         scoped = {'json': {'*'}, 'markdown': {'dialog'}}
         json_filtered = filter_dictionary(dictionary, set(), scoped, 'json')
         md_filtered = filter_dictionary(dictionary, set(), scoped, 'markdown')
@@ -1496,6 +1496,22 @@ class TestWildcardIgnore:
         assert 'color' in result
         assert 'organized' in result
         assert changes == {}
+
+    def test_corrector_cache_distinguishes_global_vs_scoped_wildcard(self, dictionary):
+        """A global '*' (dropped) and a scoped 'json:*' (disable) must not collide
+        in the corrector cache, even though their unioned tokens are identical."""
+        _corrector_cache.clear()
+
+        # Global '*' should be dropped — corrector keeps the full dictionary.
+        global_corrector = get_corrector_for_strategy(dictionary, {'*'}, {}, 'json')
+        assert len(global_corrector.dictionary) == len(dictionary)
+
+        # Scoped 'json:*' should disable the strategy — corrector is empty.
+        scoped_corrector = get_corrector_for_strategy(dictionary, set(), {'json': {'*'}}, 'json')
+        assert scoped_corrector.dictionary == {}
+
+        # The two must be distinct objects, not a cached reuse.
+        assert global_corrector is not scoped_corrector
 
     def test_end_to_end_wildcard_ignore(self, tmp_path, dictionary):
         """Full integration: wildcard in .britfixignore file."""

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1459,6 +1459,44 @@ class TestWildcardIgnore:
         filtered = filter_dictionary(dictionary, {'*'}, {}, 'text')
         assert len(filtered) == len(dictionary)
 
+    def test_scoped_bare_star_disables_strategy(self, dictionary):
+        """A scoped 'json:*' should disable the entire strategy."""
+        filtered = filter_dictionary(dictionary, set(), {'json': {'*'}}, 'json')
+        assert filtered == {}
+
+    def test_scoped_bare_star_does_not_leak_to_other_strategies(self, dictionary):
+        """A scoped 'json:*' must not affect other strategies."""
+        filtered = filter_dictionary(dictionary, set(), {'json': {'*'}}, 'markdown')
+        assert len(filtered) == len(dictionary)
+
+    def test_scoped_bare_star_combined_with_other_scoped_words(self, dictionary):
+        """'json:*' alongside 'markdown:foo' only zeroes out the JSON strategy."""
+        scoped = {'json': {'*'}, 'markdown': {'dialog'}}
+        json_filtered = filter_dictionary(dictionary, set(), scoped, 'json')
+        md_filtered = filter_dictionary(dictionary, set(), scoped, 'markdown')
+        assert json_filtered == {}
+        # markdown still has everything except 'dialog'
+        assert 'dialog' not in md_filtered
+        assert 'behavior' in md_filtered
+
+    def test_end_to_end_strategy_wildcard_skips_json(self, tmp_path, dictionary):
+        """Full integration: 'json:*' in .britfixignore skips JSON corrections."""
+        _ignore_cache.clear()
+        _corrector_cache.clear()
+
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('json:*\n')
+        json_file = tmp_path / 'settings.json'
+        json_file.write_text('{"theme": "color", "label": "organized"}\n')
+
+        g, s = discover_ignore_words(str(json_file))
+        corrector = get_corrector_for_strategy(dictionary, g, s, 'json')
+        strategy = JSONStrategy()
+        result, changes = strategy.process(json_file.read_text(), corrector)
+        assert 'color' in result
+        assert 'organized' in result
+        assert changes == {}
+
     def test_end_to_end_wildcard_ignore(self, tmp_path, dictionary):
         """Full integration: wildcard in .britfixignore file."""
         _ignore_cache.clear()


### PR DESCRIPTION
## Summary

- Added a way to disable an entire strategy via `.britfixignore` using `strategy:*` syntax (e.g. `json:*` skips all JSON value corrections).
- Reuses the existing `strategy:pattern` grammar — no new file or keyword.
- A bare `*` as a global entry is still dropped; the safety policy holds where the blast radius is dangerous.
- `filter_dictionary` now expands global and scoped ignores separately so the wildcard policy can differ between them.

Fixes #13. Pairs with #12 (and the upcoming PR for it) — users hit by the over-aggressive JSON strategy can immediately opt out with `json:*` before the heuristic fix lands.

## Test plan

- [x] New tests in `TestWildcardIgnore`:
  - `json:*` zeroes out the JSON-strategy dictionary.
  - `json:*` does not leak into other strategies.
  - `json:*` combined with `markdown:dialog` only affects JSON.
  - End-to-end: `.britfixignore` with `json:*` leaves `{"theme": "color"}` unchanged.
- [x] Existing `test_bare_star_does_not_disable_all` regression guard still passes (global `*` remains a no-op).
- [x] Full pytest suite green.

## Docs

- README updated to describe the new scoped-bare-`*` semantics alongside the existing rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)