### PR TITLE
Skip identifier-like JSON values via whitespace heuristic (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ Different file types are handled by different strategies, configured in `config.
 | **latex** | `.tex` | Skip LaTeX commands and math |
 | **html** | `.html`, `.htm`, `.xml` | Skip HTML tags and `<style>`/`<script>` content |
 | **css** | `.css`, `.scss`, `.sass`, `.less` | Only convert comments |
-| **json** | `.json` | Only convert string values |
+| **json** | `.json` | Only convert string values that contain whitespace (treats single-token strings as identifiers) |
 | **code** | `.py`, `.js`, `.ts`, etc. | Only convert comments and docstrings |
+
+### JSON File Handling
+
+JSON values are corrected only when they contain whitespace. Single-token strings — `"center"`, `"colorScheme"`, `"src/Color.tsx"` — are treated as identifiers and left alone, since most JSON values in config files are programmatic, not prose. Multi-word values like `"The organization was reorganized"` are still corrected normally.
 
 ### Code File Handling
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -744,23 +744,31 @@ class JSONStrategy(FileProcessingStrategy):
             return content, {}
 
     def _process_json_value(self, value, corrector: SpellingCorrector, change_tracker: defaultdict):
-        """Recursively process JSON values."""
+        """Recursively process JSON values.
+
+        Only string values containing whitespace are corrected. Single-token
+        strings are treated as identifiers (config values, CSS keywords, paths,
+        camelCase / snake_case names) and skipped. This avoids silently
+        rewriting programmatic values like "center" or "colorScheme".
+        """
         if isinstance(value, dict):
             for k, v in value.items():
                 if isinstance(v, str):
-                    corrected, changes = corrector.correct_text(v)
-                    value[k] = corrected
-                    for word, count in changes.items():
-                        change_tracker[word] += count
+                    if any(c.isspace() for c in v):
+                        corrected, changes = corrector.correct_text(v)
+                        value[k] = corrected
+                        for word, count in changes.items():
+                            change_tracker[word] += count
                 else:
                     self._process_json_value(v, corrector, change_tracker)
         elif isinstance(value, list):
             for i, item in enumerate(value):
                 if isinstance(item, str):
-                    corrected, changes = corrector.correct_text(item)
-                    value[i] = corrected
-                    for word, count in changes.items():
-                        change_tracker[word] += count
+                    if any(c.isspace() for c in item):
+                        corrected, changes = corrector.correct_text(item)
+                        value[i] = corrected
+                        for word, count in changes.items():
+                            change_tracker[word] += count
                 else:
                     self._process_json_value(item, corrector, change_tracker)
 

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -734,7 +734,17 @@ class JSONStrategy(FileProcessingStrategy):
         try:
             data = json.loads(content)
             total_changes = defaultdict(int)
-            self._process_json_value(data, corrector, total_changes)
+            # Root may itself be a string (valid JSON like `"hello world"`).
+            # _process_json_value walks dicts/lists and rewrites strings in
+            # place, so a string root would otherwise be missed.
+            if isinstance(data, str):
+                if any(c.isspace() for c in data):
+                    corrected, changes = corrector.correct_text(data)
+                    data = corrected
+                    for word, count in changes.items():
+                        total_changes[word] += count
+            else:
+                self._process_json_value(data, corrector, total_changes)
             return json.dumps(data, indent=2, ensure_ascii=False), dict(total_changes)
         except json.JSONDecodeError as e:
             print(

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1746,5 +1746,77 @@ class TestJSONStrategyMalformed:
         assert "color" in changes
 
 
+class TestJSONStrategyHeuristic:
+    """JSON values without whitespace are treated as identifiers and skipped.
+
+    Config files store overwhelmingly programmatic strings (CSS values, paths,
+    camelCase identifiers). Correcting them silently breaks downstream tools.
+    """
+
+    @pytest.fixture
+    def strategy(self):
+        return JSONStrategy()
+
+    def test_single_word_values_unchanged(self, strategy, corrector):
+        """Identifier-like values (no whitespace) must not be corrected."""
+        content = '{"colorScheme": "dark", "textAlign": "center"}'
+        result, changes = strategy.process(content, corrector)
+        assert '"center"' in result
+        assert '"dark"' in result
+        # Keys are also untouched (existing behaviour)
+        assert '"colorScheme"' in result
+        assert '"textAlign"' in result
+        assert changes == {}
+
+    def test_prose_values_corrected(self, strategy, corrector):
+        """Multi-word prose values still get British spellings."""
+        content = '{"description": "The organization was well organized"}'
+        result, changes = strategy.process(content, corrector)
+        assert "organisation" in result
+        assert "organised" in result
+        assert "organization" in changes
+
+    def test_single_word_prose_skipped_documents_tradeoff(self, strategy, corrector):
+        """A single-word prose value is skipped — known trade-off of the heuristic."""
+        content = '{"label": "organized"}'
+        result, changes = strategy.process(content, corrector)
+        assert '"organized"' in result
+        assert changes == {}
+
+    def test_path_like_values_unchanged(self, strategy, corrector):
+        """Paths and dotted identifiers are skipped (no whitespace)."""
+        content = '{"path": "src/Color.tsx", "module": "ui.color.scheme"}'
+        result, changes = strategy.process(content, corrector)
+        assert '"src/Color.tsx"' in result
+        assert '"ui.color.scheme"' in result
+        assert changes == {}
+
+    def test_heuristic_applies_to_nested_objects(self, strategy, corrector):
+        """The whitespace gate must apply at every depth."""
+        content = '{"outer": {"inner": "color", "prose": "The color is nice"}}'
+        result, changes = strategy.process(content, corrector)
+        assert '"color"' in result  # single-word inner skipped
+        assert "colour is nice" in result  # multi-word inner corrected
+        assert changes.get("color") == 1
+
+    def test_heuristic_applies_to_arrays(self, strategy, corrector):
+        """The whitespace gate must apply inside arrays too."""
+        content = '{"items": ["color", "behavior", "The color is nice"]}'
+        result, changes = strategy.process(content, corrector)
+        assert '"color"' in result
+        assert '"behavior"' in result
+        assert "colour is nice" in result
+        assert changes.get("color") == 1
+        assert "behavior" not in changes
+
+    def test_tab_and_newline_count_as_whitespace(self, strategy, corrector):
+        """Any whitespace character — not just space — qualifies a value as prose."""
+        content = '{"a": "color\\tbehavior", "b": "color\\nbehavior"}'
+        result, changes = strategy.process(content, corrector)
+        # Both should be corrected because they contain whitespace
+        assert "colour" in result
+        assert "behaviour" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1817,6 +1817,29 @@ class TestJSONStrategyHeuristic:
         assert "colour" in result
         assert "behaviour" in result
 
+    def test_root_string_with_whitespace_corrected(self, strategy, corrector):
+        """A bare string at the JSON root must still be reached by the heuristic."""
+        content = '"The organization was analyzed"'
+        result, changes = strategy.process(content, corrector)
+        assert "organisation" in result
+        assert "analysed" in result
+        assert changes.get("organization") == 1
+
+    def test_root_string_without_whitespace_skipped(self, strategy, corrector):
+        """A bare identifier at the JSON root is treated as an identifier."""
+        content = '"organized"'
+        result, changes = strategy.process(content, corrector)
+        # json.dumps re-quotes the string identically.
+        assert result == '"organized"'
+        assert changes == {}
+
+    def test_root_number_unaffected(self, strategy, corrector):
+        """Non-string scalar roots round-trip cleanly through the heuristic path."""
+        content = '42'
+        result, changes = strategy.process(content, corrector)
+        assert result == '42'
+        assert changes == {}
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- `JSONStrategy._process_json_value()` now corrects only string values that contain at least one whitespace character. Single-token strings — config keywords (`"center"`), camelCase identifiers (`"colorScheme"`), paths (`"src/Color.tsx"`) — are treated as identifiers and skipped.
- Multi-word prose values like `"The organization was reorganized"` are still corrected normally.
- Documented trade-off: a single-word prose value (e.g. `{"label": "organized"}`) is also skipped. This is the cost of a heuristic that can be explained in one sentence; users who need full correction can reach for inline corrections or per-file overrides.

Fixes #12. Pairs with #13 (PR #26) — together these give the JSON strategy sensible defaults plus an escape hatch.

## Test plan

- [x] New `TestJSONStrategyHeuristic` covers:
  - Identifier values (`"center"`, `"dark"`, `"colorScheme"`) untouched.
  - Multi-word prose values still corrected.
  - Single-word prose value skipped (documents the trade-off explicitly).
  - Path-like values (`"src/Color.tsx"`, `"ui.color.scheme"`) untouched.
  - Heuristic applies recursively to nested objects.
  - Heuristic applies to array elements.
  - Tab and newline count as whitespace (correction fires).
- [x] Full pytest suite green (182 passed, 1 skipped).

## Docs

- README: JSON strategy row in the file-type table updated; added a short section describing the heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)