### PR TITLE
Add phrase-level exceptions to .britfixignore (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Different file types are handled by different strategies, configured in `config.
 
 JSON values are corrected only when they contain whitespace. Single-token strings — `"center"`, `"colorScheme"`, `"src/Color.tsx"` — are treated as identifiers and left alone, since most JSON values in config files are programmatic, not prose. Multi-word values like `"The organization was reorganized"` are still corrected normally.
 
+To opt out of JSON correction entirely, add `json:*` to your `.britfixignore` (see the [strategy escape hatch](#format) below).
+
 ### Code File Handling
 
 For code files, the tool intelligently handles context:
@@ -107,15 +109,20 @@ markdown:dialog
 # Disable an entire strategy (escape hatch — equivalent to "ignore every
 # word in JSON files")
 json:*
+
+# Phrase exceptions (quoted) — preserve a multi-word phrase verbatim
+# while still correcting its constituent words elsewhere.
+"mini program"
+markdown:"mini program"
 ```
 
-- One word per line, `#` comments, blank lines skipped
-- Optional `strategy:` prefix scopes the exception to that strategy only
-- A trailing `*` acts as a prefix wildcard, ignoring the base word and all its inflected/compound forms in the dictionary (e.g. `color*` ignores `color`, `colors`, `colored`, `colorful`, `colorize`, etc.)
+- One entry per line, `#` comments, blank lines skipped
+- **Words** (bare, no quotes): `dialog`, `code:color`, optional `strategy:` prefix, optional trailing `*` for prefix wildcard (e.g. `color*` ignores `color`, `colors`, `colored`, `colorful`, `colorize`, etc.)
+- **Phrases** (quoted): `"mini program"` or `markdown:"mini program"` preserves the literal phrase wherever it appears. Words inside the phrase span are not corrected; the same words appearing elsewhere are still corrected normally. Phrase matches are case-insensitive but the original casing of the matched span is preserved.
 - A scoped bare `*` (e.g. `json:*`) disables that strategy entirely. Useful when a strategy is too broad for your project and you want to opt out without enumerating every word.
 - A global bare `*` is invalid and ignored; it does not match anything or act as "ignore everything"
 - Words use American (source) spelling (e.g. `color` not `colour`)
-- Case-insensitive
+- All matches are case-insensitive
 
 ### File Discovery
 
@@ -149,6 +156,18 @@ Running britfix on a Markdown file:
 The color is nice   ->  The colour is nice (color* is code-scoped, doesn't apply)
 Open the dialog     ->  unchanged (global dialog* exception)
 Open the dialogs    ->  unchanged (global dialog* wildcard covers inflected forms)
+```
+
+#### Phrase example
+
+With `.britfixignore`:
+```text
+"mini program"
+```
+
+```text
+Open the mini program now.    ->  unchanged ("program" is preserved inside the phrase)
+The program is great.         ->  The programme is great. (standalone "program" still corrected)
 ```
 
 ## Configuration

--- a/britfix.py
+++ b/britfix.py
@@ -327,17 +327,29 @@ Examples:
         content = sys.stdin.read()
 
         # For stdin, use only user-level ignore with "text" strategy
-        stdin_global = set()
+        stdin_global: set = set()
         stdin_scoped: dict = {}
+        stdin_global_phrases: set = set()
+        stdin_scoped_phrases: dict = {}
         user_ignore_path = get_user_ignore_path()
         if user_ignore_path and user_ignore_path.is_file():
             try:
                 user_content = user_ignore_path.read_text(encoding='utf-8')
-                stdin_global, stdin_scoped = parse_britfixignore(user_content)
+                (
+                    stdin_global,
+                    stdin_scoped,
+                    stdin_global_phrases,
+                    stdin_scoped_phrases,
+                ) = parse_britfixignore(user_content)
             except (OSError, UnicodeDecodeError):
                 pass
         stdin_corrector = get_corrector_for_strategy(
-            american_to_british, stdin_global, stdin_scoped, 'text'
+            american_to_british,
+            stdin_global,
+            stdin_scoped,
+            'text',
+            global_phrases=stdin_global_phrases,
+            scoped_phrases=stdin_scoped_phrases,
         )
 
         if args.interactive:
@@ -384,10 +396,17 @@ Examples:
             strategy = get_file_strategy(ext)
             strategy_name = get_file_strategy_name(ext)
 
-            # Discover ignore words for this file (cached by directory)
-            file_global, file_scoped = discover_ignore_words(filepath)
+            # Discover ignore rules for this file (cached by directory)
+            file_global, file_scoped, file_global_phrases, file_scoped_phrases = (
+                discover_ignore_words(filepath)
+            )
             file_corrector = get_corrector_for_strategy(
-                american_to_british, file_global, file_scoped, strategy_name
+                american_to_british,
+                file_global,
+                file_scoped,
+                strategy_name,
+                global_phrases=file_global_phrases,
+                scoped_phrases=file_scoped_phrases,
             )
 
             # Process the file

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -115,7 +115,18 @@ class SpellingCorrector:
     def _restore_phrases(self, text: str, originals: List[str]) -> str:
         if not originals:
             return text
-        return _PHRASE_PLACEHOLDER_RE.sub(lambda m: originals[int(m.group(1))], text)
+
+        def restore(match):
+            idx = int(match.group(1))
+            # Guard against the (vanishingly unlikely) case where user content
+            # already contained the delimiter pattern with a bogus index. Leave
+            # such matches untouched rather than IndexError-ing or rewriting
+            # unrelated text.
+            if 0 <= idx < len(originals):
+                return originals[idx]
+            return match.group(0)
+
+        return _PHRASE_PLACEHOLDER_RE.sub(restore, text)
 
     def _phrase_spans(self, text: str) -> List[Tuple[int, int]]:
         """Return non-overlapping (start, end) spans of phrase matches in ``text``."""
@@ -1107,7 +1118,7 @@ def is_code_file(file_extension: str) -> bool:
 # --- .britfixignore support ---
 
 _PHRASE_LINE_RE = re.compile(r'^"([^"]+)"$')
-_SCOPED_PHRASE_LINE_RE = re.compile(r'^([A-Za-z][A-Za-z0-9_-]*):"([^"]+)"$')
+_SCOPED_PHRASE_LINE_RE = re.compile(r'^([A-Za-z][A-Za-z0-9_-]*)\s*:\s*"([^"]+)"$')
 
 
 def parse_britfixignore(
@@ -1394,13 +1405,18 @@ def get_corrector_for_strategy(
     s_phrases = (scoped_phrases or {}).get(strategy_name, set())
     effective_phrases = g_phrases | s_phrases
 
+    # Phrases are matched case-insensitively, so canonicalise on lowercase for
+    # the cache key. Two phrase sets that differ only in casing produce the
+    # same corrector behaviour and should share a cache entry. Original casing
+    # is preserved in the corrector itself (and ultimately in the matched
+    # span's output) regardless of what's in the cache key.
     cache_key = (
         id(base_dictionary),
         strategy_name,
         frozenset(global_ignores),
         frozenset(strategy_ignores),
-        frozenset(g_phrases),
-        frozenset(s_phrases),
+        frozenset(p.lower() for p in g_phrases),
+        frozenset(p.lower() for p in s_phrases),
     )
     if cache_key in _corrector_cache:
         return _corrector_cache[cache_key]

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -62,12 +62,30 @@ except ConfigError as e:
     print(f"Britfix config error: {e}", file=sys.stderr)
     sys.exit(1)
 
-class SpellingCorrector:
-    """Efficient spelling corrector with precompiled regex patterns."""
+# Private-use Unicode codepoint used to delimit phrase placeholders during the
+# mask-correct-restore pass in SpellingCorrector. Picked because it is non-word
+# (so dictionary regex word boundaries treat it as text junction) and is
+# vanishingly unlikely to appear in real source content.
+_PHRASE_MASK_DELIM = ''
+_PHRASE_PLACEHOLDER_RE = re.compile(
+    re.escape(_PHRASE_MASK_DELIM) + r'(\d+)' + re.escape(_PHRASE_MASK_DELIM)
+)
 
-    def __init__(self, dictionary: Dict[str, str]):
+
+class SpellingCorrector:
+    """Efficient spelling corrector with precompiled regex patterns.
+
+    ``phrases`` are literal substrings (case-insensitive) that should be
+    preserved verbatim — any dictionary word that falls inside a phrase match
+    is left untouched. See ``correct_text`` for the masking pass.
+    """
+
+    def __init__(self, dictionary: Dict[str, str], phrases: Optional[Set[str]] = None):
         self.dictionary = {k.lower(): v for k, v in dictionary.items()}
         self.pattern = self._compile_pattern()
+        # Sort phrases by length descending so longer phrases win when alternatives overlap.
+        self._phrases = sorted({p for p in (phrases or set()) if p}, key=len, reverse=True)
+        self._phrase_pattern = self._compile_phrase_pattern()
 
     def _compile_pattern(self) -> Optional[re.Pattern]:
         """Compile regex pattern for all dictionary words."""
@@ -75,7 +93,36 @@ class SpellingCorrector:
             return None
         pattern = r'\b(' + '|'.join(re.escape(word) for word in self.dictionary.keys()) + r')\b'
         return re.compile(pattern, re.IGNORECASE)
-    
+
+    def _compile_phrase_pattern(self) -> Optional[re.Pattern]:
+        if not self._phrases:
+            return None
+        return re.compile('|'.join(re.escape(p) for p in self._phrases), re.IGNORECASE)
+
+    def _mask_phrases(self, text: str) -> Tuple[str, List[str]]:
+        """Replace phrase matches with placeholders. Returns (masked_text, originals)."""
+        if not self._phrase_pattern:
+            return text, []
+        originals: List[str] = []
+
+        def stash(match):
+            originals.append(match.group())
+            return f"{_PHRASE_MASK_DELIM}{len(originals) - 1}{_PHRASE_MASK_DELIM}"
+
+        masked = self._phrase_pattern.sub(stash, text)
+        return masked, originals
+
+    def _restore_phrases(self, text: str, originals: List[str]) -> str:
+        if not originals:
+            return text
+        return _PHRASE_PLACEHOLDER_RE.sub(lambda m: originals[int(m.group(1))], text)
+
+    def _phrase_spans(self, text: str) -> List[Tuple[int, int]]:
+        """Return non-overlapping (start, end) spans of phrase matches in ``text``."""
+        if not self._phrase_pattern:
+            return []
+        return [(m.start(), m.end()) for m in self._phrase_pattern.finditer(text)]
+
     def detect_case(self, word: str) -> str:
         """Detect the case pattern of a word."""
         if word.isupper():
@@ -86,7 +133,7 @@ class SpellingCorrector:
             return 'title'
         else:
             return 'mixed'
-    
+
     def apply_case(self, word: str, case_pattern: str) -> str:
         """Apply the detected case pattern to a word."""
         if case_pattern == 'upper':
@@ -97,48 +144,61 @@ class SpellingCorrector:
             return word.title()
         else:
             return word
-    
+
     def find_replacements(self, text: str) -> List[Tuple[int, int, str, str]]:
         """Find all potential replacements in text."""
         if not self.pattern:
             return []
-            
+
+        phrase_spans = self._phrase_spans(text)
         replacements = []
-        
+
         for match in self.pattern.finditer(text):
+            ms, me = match.start(), match.end()
+            # Drop any candidate that overlaps a preserved phrase span.
+            if any(ps < me and ms < pe for ps, pe in phrase_spans):
+                continue
             original_word = match.group()
             case_pattern = self.detect_case(original_word)
             key = original_word.lower()
-            
+
             if key in self.dictionary:
                 british_spelling = self.dictionary[key]
                 replacement = self.apply_case(british_spelling, case_pattern)
                 if original_word != replacement:
-                    replacements.append((match.start(), match.end(), original_word, replacement))
-        
+                    replacements.append((ms, me, original_word, replacement))
+
         return replacements
-    
+
     def correct_text(self, text: str, track_changes: bool = True) -> Tuple[str, Dict[str, int]]:
-        """Apply spelling corrections to text."""
+        """Apply spelling corrections to text.
+
+        If phrase ignores are configured, phrases are masked with placeholder
+        tokens before dictionary correction runs and restored afterwards.
+        Words that fall inside a phrase match are therefore preserved verbatim.
+        """
         if not self.pattern:
             return text, {}
-            
+
+        masked, originals = self._mask_phrases(text)
+
         change_tracker = defaultdict(int) if track_changes else None
-        
+
         def replacement(match):
             original_word = match.group()
             case_pattern = self.detect_case(original_word)
             key = original_word.lower()
-            
+
             if key in self.dictionary:
                 british_spelling = self.dictionary[key]
                 if track_changes:
                     change_tracker[key] += 1
                 return self.apply_case(british_spelling, case_pattern)
-            
+
             return original_word
-        
-        corrected_text = self.pattern.sub(replacement, text)
+
+        corrected_text = self.pattern.sub(replacement, masked)
+        corrected_text = self._restore_phrases(corrected_text, originals)
         return corrected_text, dict(change_tracker) if track_changes else {}
 
 
@@ -1046,22 +1106,58 @@ def is_code_file(file_extension: str) -> bool:
 
 # --- .britfixignore support ---
 
-def parse_britfixignore(content: str) -> Tuple[Set[str], Dict[str, Set[str]]]:
+_PHRASE_LINE_RE = re.compile(r'^"([^"]+)"$')
+_SCOPED_PHRASE_LINE_RE = re.compile(r'^([A-Za-z][A-Za-z0-9_-]*):"([^"]+)"$')
+
+
+def parse_britfixignore(
+    content: str,
+) -> Tuple[Set[str], Dict[str, Set[str]], Set[str], Dict[str, Set[str]]]:
     """Parse a .britfixignore file.
 
-    Returns (global_ignores, scoped_ignores) where scoped_ignores maps
-    strategy name -> set of words. Words are lowercased. Unknown strategy
-    names produce a warning on stderr and are skipped.
+    Returns ``(global_words, scoped_words, global_phrases, scoped_phrases)``.
+
+    - Bare lines (``dialog``) and ``strategy:word`` lines are word-level
+      ignores, lowercased and matched case-insensitively.
+    - Quoted lines (``"mini program"``) and ``strategy:"mini program"`` lines
+      are phrase-level ignores. Phrases are matched case-insensitively but
+      the original casing of the matched span is preserved in output.
+
+    Unknown strategy names produce a warning on stderr and are skipped.
     """
     valid_strategies = set(_CONFIG['strategies'].keys())
-    global_ignores: Set[str] = set()
-    scoped_ignores: Dict[str, Set[str]] = {}
+    global_words: Set[str] = set()
+    scoped_words: Dict[str, Set[str]] = {}
+    global_phrases: Set[str] = set()
+    scoped_phrases: Dict[str, Set[str]] = {}
 
     for line in content.splitlines():
         line = line.strip()
         if not line or line.startswith('#'):
             continue
 
+        # Try strategy-scoped phrase first (most specific form).
+        m = _SCOPED_PHRASE_LINE_RE.match(line)
+        if m:
+            strategy_name = m.group(1).lower()
+            phrase = m.group(2)
+            if strategy_name not in valid_strategies:
+                safe_name = strategy_name.encode('unicode_escape').decode('ascii')
+                print(
+                    f"britfix: unknown strategy '{safe_name}' in .britfixignore, skipping",
+                    file=sys.stderr,
+                )
+                continue
+            scoped_phrases.setdefault(strategy_name, set()).add(phrase)
+            continue
+
+        # Then unscoped phrase.
+        m = _PHRASE_LINE_RE.match(line)
+        if m:
+            global_phrases.add(m.group(1))
+            continue
+
+        # Fall back to existing word-level handling.
         if ':' in line:
             strategy_name, _, word = line.partition(':')
             strategy_name = strategy_name.strip().lower()
@@ -1072,13 +1168,13 @@ def parse_britfixignore(content: str) -> Tuple[Set[str], Dict[str, Set[str]]]:
                 safe_name = strategy_name.encode('unicode_escape').decode('ascii')
                 print(f"britfix: unknown strategy '{safe_name}' in .britfixignore, skipping", file=sys.stderr)
                 continue
-            if strategy_name not in scoped_ignores:
-                scoped_ignores[strategy_name] = set()
-            scoped_ignores[strategy_name].add(word)
+            if strategy_name not in scoped_words:
+                scoped_words[strategy_name] = set()
+            scoped_words[strategy_name].add(word)
         else:
-            global_ignores.add(line.lower())
+            global_words.add(line.lower())
 
-    return global_ignores, scoped_ignores
+    return global_words, scoped_words, global_phrases, scoped_phrases
 
 
 def get_user_ignore_path() -> Optional[Path]:
@@ -1101,28 +1197,37 @@ def get_user_ignore_path() -> Optional[Path]:
         return base / 'britfix' / 'ignore'
 
 
-# Cache for ignore lookups by directory path
-_ignore_cache: Dict[str, Tuple[Set[str], Dict[str, Set[str]]]] = {}
+# Cache for ignore lookups by directory path. Each value is the 4-tuple
+# returned by parse_britfixignore: global_words, scoped_words, global_phrases,
+# scoped_phrases.
+IgnoreRules = Tuple[Set[str], Dict[str, Set[str]], Set[str], Dict[str, Set[str]]]
+_ignore_cache: Dict[str, IgnoreRules] = {}
 
 
-def _merge_ignores(
-    base: Tuple[Set[str], Dict[str, Set[str]]],
-    overlay: Tuple[Set[str], Dict[str, Set[str]]],
-) -> Tuple[Set[str], Dict[str, Set[str]]]:
-    """Merge two ignore tuples additively (union)."""
-    merged_global = base[0] | overlay[0]
-    merged_scoped: Dict[str, Set[str]] = {}
-    for key in set(base[1].keys()) | set(overlay[1].keys()):
-        merged_scoped[key] = base[1].get(key, set()) | overlay[1].get(key, set())
-    return merged_global, merged_scoped
+def _merge_scoped(base: Dict[str, Set[str]], overlay: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
+    merged: Dict[str, Set[str]] = {}
+    for key in set(base.keys()) | set(overlay.keys()):
+        merged[key] = base.get(key, set()) | overlay.get(key, set())
+    return merged
 
 
-def discover_ignore_words(file_path: str) -> Tuple[Set[str], Dict[str, Set[str]]]:
-    """Discover .britfixignore words for a given file.
+def _merge_ignores(base: IgnoreRules, overlay: IgnoreRules) -> IgnoreRules:
+    """Merge two ignore-rule tuples additively (union)."""
+    return (
+        base[0] | overlay[0],
+        _merge_scoped(base[1], overlay[1]),
+        base[2] | overlay[2],
+        _merge_scoped(base[3], overlay[3]),
+    )
+
+
+def discover_ignore_words(file_path: str) -> IgnoreRules:
+    """Discover .britfixignore rules for a given file.
 
     Walks up from the file's directory to the nearest .git boundary or
     Path.home(), collects .britfixignore files root->leaf, merges with
-    user config. Results are cached by directory.
+    user config. Returns ``(global_words, scoped_words, global_phrases,
+    scoped_phrases)``. Results are cached by directory.
     """
     resolved = Path(file_path).resolve()
     file_dir = resolved.parent if resolved.is_file() or not resolved.exists() else resolved
@@ -1166,7 +1271,7 @@ def discover_ignore_words(file_path: str) -> Tuple[Set[str], Dict[str, Set[str]]
             ignore_files.append(candidate)
 
     # Start with user config
-    result: Tuple[Set[str], Dict[str, Set[str]]] = (set(), {})
+    result: IgnoreRules = (set(), {}, set(), {})
     user_path = get_user_ignore_path()
     if user_path and user_path.is_file():
         try:
@@ -1264,14 +1369,14 @@ def filter_dictionary(
     return {k: v for k, v in dictionary.items() if k.lower() not in expanded}
 
 
-# Cache for correctors keyed by (dict_id, strategy_name, frozenset(global), frozenset(scoped)).
-# Uses id() for the dictionary — safe because the dictionary object is kept alive
-# for the entire CLI run, so the id cannot be reused by a different object.
-# Global and scoped ignores are kept as separate frozensets in the key so that
-# wildcard tokens like ``*`` (which have different semantics in each scope —
-# global ``*`` is dropped, scoped ``json:*`` disables a strategy) cannot
-# collide in the cache.
-_corrector_cache: Dict[Tuple[int, str, frozenset, frozenset], SpellingCorrector] = {}
+# Cache for correctors keyed by (dict_id, strategy_name, frozensets of each
+# ignore-rule kind). Uses id() for the dictionary — safe because the dictionary
+# object is kept alive for the entire CLI run, so the id cannot be reused by a
+# different object. Global and scoped sets are kept separate so that wildcard
+# tokens like ``*`` (whose semantics differ between scopes) cannot collide.
+_corrector_cache: Dict[
+    Tuple[int, str, frozenset, frozenset, frozenset, frozenset], SpellingCorrector
+] = {}
 
 
 def get_corrector_for_strategy(
@@ -1279,20 +1384,28 @@ def get_corrector_for_strategy(
     global_ignores: Set[str],
     scoped_ignores: Dict[str, Set[str]],
     strategy_name: str,
+    global_phrases: Optional[Set[str]] = None,
+    scoped_phrases: Optional[Dict[str, Set[str]]] = None,
 ) -> SpellingCorrector:
-    """Get a (cached) SpellingCorrector with ignored words filtered out."""
+    """Get a (cached) SpellingCorrector with ignored words filtered out and
+    quoted phrases configured for in-text masking."""
     strategy_ignores = scoped_ignores.get(strategy_name, set())
+    g_phrases = global_phrases or set()
+    s_phrases = (scoped_phrases or {}).get(strategy_name, set())
+    effective_phrases = g_phrases | s_phrases
 
     cache_key = (
         id(base_dictionary),
         strategy_name,
         frozenset(global_ignores),
         frozenset(strategy_ignores),
+        frozenset(g_phrases),
+        frozenset(s_phrases),
     )
     if cache_key in _corrector_cache:
         return _corrector_cache[cache_key]
 
     filtered = filter_dictionary(base_dictionary, global_ignores, scoped_ignores, strategy_name)
-    corrector = SpellingCorrector(filtered)
+    corrector = SpellingCorrector(filtered, phrases=effective_phrases)
     _corrector_cache[cache_key] = corrector
     return corrector

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1312,6 +1312,17 @@ class TestBritfixIgnorePhraseParsing:
         assert 'unknown strategy' in captured.err
         assert sp == {}
 
+    def test_scoped_phrase_allows_whitespace_around_colon(self):
+        """Whitespace around the ':' is tolerated in scoped phrases, matching
+        the existing word-parsing behaviour (`code : dialog` is also accepted)."""
+        content = 'markdown : "mini program"\nhtml :"power user"\ncss: "dark mode"\n'
+        g, s, gp, sp = parse_britfixignore(content)
+        assert sp == {
+            'markdown': {'mini program'},
+            'html': {'power user'},
+            'css': {'dark mode'},
+        }
+
 
 class TestSpellingCorrectorPhraseMasking:
     """SpellingCorrector preserves phrase matches verbatim during correction."""
@@ -1369,6 +1380,21 @@ class TestSpellingCorrectorPhraseMasking:
         assert 'favourable' in result
         assert 'mini program' in result
 
+    def test_user_text_containing_delimiter_pattern_is_safe(self, dictionary):
+        """If user content already contains the placeholder delimiter pattern
+        with an out-of-range index, restoration must leave it untouched rather
+        than IndexError or rewrite unrelated text."""
+        from britfix_core import _PHRASE_MASK_DELIM
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        # Note: no phrase matches in this text, so originals=[]. The delimiter
+        # pattern with an out-of-range index appears via the user input itself.
+        bogus_placeholder = f"{_PHRASE_MASK_DELIM}9{_PHRASE_MASK_DELIM}"
+        text = f"The color is {bogus_placeholder} nice."
+        result, _ = corrector.correct_text(text)
+        # 'color' still corrected; the bogus placeholder survives unchanged.
+        assert 'colour' in result
+        assert bogus_placeholder in result
+
 
 class TestPhraseIntegration:
     """End-to-end: .britfixignore phrase entries flow through to correction."""
@@ -1421,6 +1447,20 @@ class TestPhraseIntegration:
             global_phrases={'open program'}, scoped_phrases={},
         )
         assert a is not b
+
+    def test_corrector_cache_normalises_phrase_casing(self, dictionary):
+        """Phrases that differ only in case match identically (case-insensitive)
+        and so must share a cache entry rather than producing duplicates."""
+        _corrector_cache.clear()
+        a = get_corrector_for_strategy(
+            dictionary, set(), {}, 'text',
+            global_phrases={'Mini Program'}, scoped_phrases={},
+        )
+        b = get_corrector_for_strategy(
+            dictionary, set(), {}, 'text',
+            global_phrases={'mini program'}, scoped_phrases={},
+        )
+        assert a is b
 
     def test_end_to_end_phrase_in_britfixignore(self, tmp_path, dictionary):
         _ignore_cache.clear()

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -1052,49 +1052,49 @@ class TestBritfixIgnoreParsing:
     """Test .britfixignore file parsing."""
 
     def test_empty_file(self):
-        g, s = parse_britfixignore('')
+        g, s, _, _ = parse_britfixignore('')
         assert g == set()
         assert s == {}
 
     def test_comments_and_blank_lines(self):
         content = "# a comment\n\n# another\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == set()
         assert s == {}
 
     def test_global_words(self):
         content = "color\nbehavior\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == {'color', 'behavior'}
         assert s == {}
 
     def test_scoped_words(self):
         content = "code:color\nmarkdown:dialog\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == set()
         assert s == {'code': {'color'}, 'markdown': {'dialog'}}
 
     def test_mixed_global_and_scoped(self):
         content = "color\ncode:dialog\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == {'color'}
         assert s == {'code': {'dialog'}}
 
     def test_whitespace_handling(self):
         content = "  color  \n  code : dialog  \n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert 'color' in g
         assert 'dialog' in s.get('code', set())
 
     def test_case_insensitivity(self):
         content = "Color\nCode:Dialog\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert 'color' in g
         assert 'dialog' in s.get('code', set())
 
     def test_unknown_strategy_warns(self, capsys):
         content = "bogus:color\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == set()
         assert s == {}
         captured = capsys.readouterr()
@@ -1102,13 +1102,13 @@ class TestBritfixIgnoreParsing:
 
     def test_empty_word_after_colon_skipped(self):
         content = "code:\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert g == set()
         assert s == {}
 
     def test_multiple_words_same_strategy(self):
         content = "code:color\ncode:dialog\ncode:center\n"
-        g, s = parse_britfixignore(content)
+        g, s, _, _ = parse_britfixignore(content)
         assert s == {'code': {'color', 'dialog', 'center'}}
 
 
@@ -1130,7 +1130,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'sub' / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' in g
 
     def test_nested_dirs_merge(self, tmp_path):
@@ -1142,7 +1142,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'sub' / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' in g
         assert 'behavior' in g
 
@@ -1155,7 +1155,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'sub' / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert s.get('code') == {'color', 'dialog'}
 
     def test_stops_at_home_dir(self, tmp_path, monkeypatch):
@@ -1171,7 +1171,7 @@ class TestBritfixIgnoreDiscovery:
         target = project / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' not in g
 
     def test_worktree_git_file(self, tmp_path):
@@ -1181,7 +1181,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' in g
 
     def test_user_config_merged(self, tmp_path, monkeypatch):
@@ -1197,7 +1197,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' in g
         assert 'behavior' in g
 
@@ -1229,7 +1229,7 @@ class TestBritfixIgnoreDiscovery:
         target = project / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert 'color' in g
 
     def test_invalid_utf8_ignore_file_skipped(self, tmp_path):
@@ -1241,7 +1241,7 @@ class TestBritfixIgnoreDiscovery:
         target.touch()
 
         # Should not raise, should return empty ignores
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert isinstance(g, set)
         assert isinstance(s, dict)
 
@@ -1256,7 +1256,7 @@ class TestBritfixIgnoreDiscovery:
         target = tmp_path / 'file.py'
         target.touch()
 
-        g, s = discover_ignore_words(str(target))
+        g, s, _, _ = discover_ignore_words(str(target))
         assert isinstance(g, set)
 
 
@@ -1271,6 +1271,173 @@ class TestBritfixIgnoreParsingEdgeCases:
         # The raw escape should not appear in stderr
         assert '\x1b[' not in captured.err
         assert 'unknown strategy' in captured.err
+
+
+class TestBritfixIgnorePhraseParsing:
+    """Quoted phrase entries in .britfixignore."""
+
+    def test_global_phrase_parsed(self):
+        g, s, gp, sp = parse_britfixignore('"mini program"\n')
+        assert gp == {'mini program'}
+        assert g == set()
+        assert sp == {}
+
+    def test_scoped_phrase_parsed(self):
+        g, s, gp, sp = parse_britfixignore('markdown:"mini program"\n')
+        assert sp == {'markdown': {'mini program'}}
+        assert gp == set()
+        assert s == {}
+
+    def test_phrase_preserves_original_casing(self):
+        """Phrases are stored verbatim — casing is preserved for restoration."""
+        g, s, gp, sp = parse_britfixignore('"Mini Program"\n')
+        assert gp == {'Mini Program'}
+
+    def test_phrase_with_punctuation_and_inner_spaces(self):
+        g, s, gp, sp = parse_britfixignore('"the United States of America"\n')
+        assert gp == {'the United States of America'}
+
+    def test_words_and_phrases_coexist(self):
+        content = '"mini program"\ndialog\ncode:color\nmarkdown:"power user"\n'
+        g, s, gp, sp = parse_britfixignore(content)
+        assert g == {'dialog'}
+        assert s == {'code': {'color'}}
+        assert gp == {'mini program'}
+        assert sp == {'markdown': {'power user'}}
+
+    def test_unknown_strategy_for_scoped_phrase_warns(self, capsys):
+        content = 'bogus:"mini program"\n'
+        g, s, gp, sp = parse_britfixignore(content)
+        captured = capsys.readouterr()
+        assert 'unknown strategy' in captured.err
+        assert sp == {}
+
+
+class TestSpellingCorrectorPhraseMasking:
+    """SpellingCorrector preserves phrase matches verbatim during correction."""
+
+    @pytest.fixture
+    def dictionary(self):
+        return load_spelling_mappings()
+
+    def test_no_phrases_unchanged_behaviour(self, dictionary):
+        """Without phrases, correct_text behaves exactly as before."""
+        corrector = SpellingCorrector(dictionary)
+        result, _ = corrector.correct_text('The color is nice.')
+        assert result == 'The colour is nice.'
+
+    def test_phrase_in_text_preserved(self, dictionary):
+        """Words inside a phrase match are not corrected; standalone uses still are."""
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        result, _ = corrector.correct_text('A mini program runs the program well.')
+        # Inside the phrase: 'program' preserved.
+        assert 'mini program' in result
+        # Standalone: 'program' becomes 'programme'.
+        assert 'runs the programme well' in result
+
+    def test_phrase_match_is_case_insensitive(self, dictionary):
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        result, _ = corrector.correct_text('Open Mini Program now.')
+        assert 'Mini Program' in result  # original casing preserved
+
+    def test_longer_phrase_wins_over_shorter(self, dictionary):
+        """Overlapping phrases: longer matches win (sorted descending by length)."""
+        corrector = SpellingCorrector(dictionary, phrases={'color', 'color scheme'})
+        result, _ = corrector.correct_text('Pick a color scheme today.')
+        assert 'color scheme' in result  # longer phrase wins, both words preserved
+
+    def test_change_tracker_excludes_phrase_words(self, dictionary):
+        """Tracked changes must not count words that fell inside a phrase span."""
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        _, changes = corrector.correct_text('A mini program. The program ran.')
+        # Only one 'program' was outside the phrase and got corrected.
+        assert changes.get('program') == 1
+
+    def test_find_replacements_skips_phrase_overlaps(self, dictionary):
+        """Interactive mode must not offer changes inside phrase spans."""
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        repls = corrector.find_replacements('A mini program. The program ran.')
+        # Exactly one replacement: the standalone 'program'.
+        assert len(repls) == 1
+        assert repls[0][2] == 'program'
+        assert repls[0][0] > len('A mini program')  # position outside phrase
+
+    def test_phrase_does_not_break_unrelated_corrections(self, dictionary):
+        corrector = SpellingCorrector(dictionary, phrases={'mini program'})
+        result, _ = corrector.correct_text('The color of the mini program was favorable.')
+        assert 'colour' in result
+        assert 'favourable' in result
+        assert 'mini program' in result
+
+
+class TestPhraseIntegration:
+    """End-to-end: .britfixignore phrase entries flow through to correction."""
+
+    @pytest.fixture
+    def dictionary(self):
+        return load_spelling_mappings()
+
+    def test_global_phrase_via_corrector_factory(self, dictionary):
+        _ignore_cache.clear()
+        _corrector_cache.clear()
+        corrector = get_corrector_for_strategy(
+            dictionary,
+            global_ignores=set(),
+            scoped_ignores={},
+            strategy_name='text',
+            global_phrases={'mini program'},
+            scoped_phrases={},
+        )
+        result, _ = corrector.correct_text('mini program then program alone')
+        assert 'mini program' in result
+        assert 'programme alone' in result
+
+    def test_scoped_phrase_only_applies_to_matching_strategy(self, dictionary):
+        _ignore_cache.clear()
+        _corrector_cache.clear()
+        scoped = {'markdown': {'mini program'}}
+        md_corrector = get_corrector_for_strategy(
+            dictionary, set(), {}, 'markdown',
+            global_phrases=set(), scoped_phrases=scoped,
+        )
+        text_corrector = get_corrector_for_strategy(
+            dictionary, set(), {}, 'text',
+            global_phrases=set(), scoped_phrases=scoped,
+        )
+        md_result, _ = md_corrector.correct_text('mini program')
+        text_result, _ = text_corrector.correct_text('mini program')
+        assert 'mini program' in md_result
+        assert 'mini programme' in text_result  # text strategy still corrects
+
+    def test_corrector_cache_distinguishes_phrase_sets(self, dictionary):
+        """Two correctors that differ only in phrases must not collide in the cache."""
+        _corrector_cache.clear()
+        a = get_corrector_for_strategy(
+            dictionary, set(), {}, 'text',
+            global_phrases={'mini program'}, scoped_phrases={},
+        )
+        b = get_corrector_for_strategy(
+            dictionary, set(), {}, 'text',
+            global_phrases={'open program'}, scoped_phrases={},
+        )
+        assert a is not b
+
+    def test_end_to_end_phrase_in_britfixignore(self, tmp_path, dictionary):
+        _ignore_cache.clear()
+        _corrector_cache.clear()
+        (tmp_path / '.git').mkdir()
+        (tmp_path / '.britfixignore').write_text('"mini program"\n')
+        md_file = tmp_path / 'doc.md'
+        md_file.write_text('Open the mini program; the program is great.\n')
+        g, s, gp, sp = discover_ignore_words(str(md_file))
+        corrector = get_corrector_for_strategy(
+            dictionary, g, s, 'markdown',
+            global_phrases=gp, scoped_phrases=sp,
+        )
+        strategy = MarkdownStrategy()
+        result, _ = strategy.process(md_file.read_text(), corrector)
+        assert 'mini program' in result
+        assert 'the programme is great' in result
 
 
 class TestFilteredCorrector:
@@ -1380,7 +1547,7 @@ class TestIgnoreIntegration:
         txt_file.write_text('The color is nice\n')
 
         # Python file: color should be ignored (code strategy)
-        g, s = discover_ignore_words(str(py_file))
+        g, s, _, _ = discover_ignore_words(str(py_file))
         py_corrector = get_corrector_for_strategy(dictionary, g, s, 'code')
         strategy = CodeStrategy()
         result, _ = strategy.process(py_file.read_text(), py_corrector)
@@ -1389,7 +1556,7 @@ class TestIgnoreIntegration:
 
         # Text file: color should NOT be ignored (text strategy)
         _ignore_cache.clear()
-        g, s = discover_ignore_words(str(txt_file))
+        g, s, _, _ = discover_ignore_words(str(txt_file))
         txt_corrector = get_corrector_for_strategy(dictionary, g, s, 'text')
         strategy = PlainTextStrategy()
         result, _ = strategy.process(txt_file.read_text(), txt_corrector)
@@ -1439,7 +1606,7 @@ class TestWildcardIgnore:
     def test_parse_preserves_wildcard(self):
         """parse_britfixignore should keep trailing * in words."""
         content = "dialog*\ncode:color*\n"
-        global_ig, scoped_ig = parse_britfixignore(content)
+        global_ig, scoped_ig, _, _ = parse_britfixignore(content)
         assert 'dialog*' in global_ig
         assert 'color*' in scoped_ig.get('code', set())
 
@@ -1489,7 +1656,7 @@ class TestWildcardIgnore:
         json_file = tmp_path / 'settings.json'
         json_file.write_text('{"theme": "color", "label": "organized"}\n')
 
-        g, s = discover_ignore_words(str(json_file))
+        g, s, _, _ = discover_ignore_words(str(json_file))
         corrector = get_corrector_for_strategy(dictionary, g, s, 'json')
         strategy = JSONStrategy()
         result, changes = strategy.process(json_file.read_text(), corrector)
@@ -1523,7 +1690,7 @@ class TestWildcardIgnore:
         md_file = tmp_path / 'test.md'
         md_file.write_text('The dialog and dialogs are shown.\n')
 
-        g, s = discover_ignore_words(str(md_file))
+        g, s, _, _ = discover_ignore_words(str(md_file))
         corrector = get_corrector_for_strategy(dictionary, g, s, 'markdown')
         strategy = MarkdownStrategy()
         result, changes = strategy.process(md_file.read_text(), corrector)


### PR DESCRIPTION
## Summary

Quoted entries in `.britfixignore` now denote phrases that must be preserved verbatim:

```text
"mini program"
markdown:"mini program"
```

A word that falls inside a phrase span is left untouched; the same word appearing elsewhere (`The program is great`) is still corrected normally (`The programme is great`). Matches are case-insensitive; the original casing of the matched span is preserved in output. Sibling phrases are sorted by length descending, so longer matches win.

Bundled with: a small README cross-reference between the JSON whitespace heuristic (#27) and the `json:*` escape hatch (#26) that couldn't be linked when they shipped on independent branches.

Fixes #14.

## Implementation notes

- `SpellingCorrector` accepts an optional `phrases` set. `correct_text` masks phrase matches with a private-use Unicode delimiter (`U+E8A2`) before running dictionary correction, then restores them. `find_replacements` filters out any candidate whose span overlaps a phrase, so interactive mode and `process()` agree on what fires.
- `parse_britfixignore` and `discover_ignore_words` now return a 4-tuple: `(global_words, scoped_words, global_phrases, scoped_phrases)`. Existing tests updated to unpack the widened tuple.
- `get_corrector_for_strategy` threads phrases through and includes both global and scoped phrase frozensets in the cache key, so correctors with different phrase configurations don't collide.

### Design deviation from the original plan

The plan suggested passing `phrase_ignores` directly into `correct_text`, which would have required modifying every strategy's `process()` method (~11 call sites of `corrector.correct_text`). Putting phrases inside `SpellingCorrector` keeps the strategy API unchanged and centralises masking in one place. Same external semantics, far less churn.

## Test plan

- [x] New `TestBritfixIgnorePhraseParsing` (6 tests): global / scoped / casing / punctuation / coexistence with words / unknown-strategy warning.
- [x] New `TestSpellingCorrectorPhraseMasking` (7 tests): no-phrase regression, in-text preservation, case-insensitive match, longer-phrase-wins for overlaps, change tracker excludes phrase words, `find_replacements` skips phrase overlaps, unrelated corrections still fire.
- [x] New `TestPhraseIntegration` (4 tests): factory wiring, scope leakage guard, cache distinguishes phrase sets, end-to-end via `discover_ignore_words` + `MarkdownStrategy.process`.
- [x] Existing tests updated to unpack the 4-tuple from the parser/discovery functions; all pass unchanged otherwise.
- [x] Full pytest suite green (214 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)