### PR TITLE
Preserve markdown link targets in markdown strategy

### DIFF
--- a/britfix_core.py
+++ b/britfix_core.py
@@ -516,13 +516,23 @@ class MarkdownStrategy(FileProcessingStrategy):
                 # Split on HTML tags so attribute values aren't corrected
                 # Require tag-like structure: < then letter or / to avoid matching bare < in prose
                 tag_pattern = r'(</?[a-zA-Z][^>]*>)'
+                # Split on markdown link targets `](url)` (optional title inside) so
+                # URLs aren't corrected. Matches `](...)` where `...` has no `)`.
+                # Preserves the `](url)` / `](url "title")` span; the preceding `[text`
+                # stays in prose so link text is still corrected.
+                link_target_pattern = r'(\]\([^)]*\))'
                 parts = re.split(tag_pattern, segment)
                 for idx, part in enumerate(parts):
                     if idx % 2 == 0:  # Text outside tags
-                        corrected, changes = corrector.correct_text(part)
-                        result.append(corrected)
-                        for word, count in changes.items():
-                            total_changes[word] += count
+                        link_parts = re.split(link_target_pattern, part)
+                        for lidx, lpart in enumerate(link_parts):
+                            if lidx % 2 == 0:  # Prose around link targets
+                                corrected, changes = corrector.correct_text(lpart)
+                                result.append(corrected)
+                                for word, count in changes.items():
+                                    total_changes[word] += count
+                            else:  # Link target `](url)` — preserve unchanged
+                                result.append(lpart)
                     else:  # HTML tag — preserve unchanged
                         result.append(part)
 

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -596,6 +596,21 @@ More color."""
         assert 'href="https://example.com/organized"' in result
         assert "for colour" in result
 
+    def test_wikipedia_style_url_with_nested_parens_preserved(self, strategy, corrector):
+        """A wiki-style URL with a single nested `(…)` preserves correctly.
+
+        The regex stops at the first `)`, which closes the inner parenthesised
+        segment; the stray outer `)` falls through as prose with nothing to
+        correct. URLs with deeper nesting or unescaped trailing parens are
+        declared out of scope, but this common case is pinned here so a future
+        tightening of the regex doesn't silently regress it.
+        """
+        text = "See [Link](https://en.wikipedia.org/wiki/Link_(organized)) for color."
+        result, changes = strategy.process(text, corrector)
+        assert "wiki/Link_(organized)" in result
+        assert "organised" not in result
+        assert "for colour" in result
+
 
 class TestMarkdownStrategyMapping:
     """Test that markdown file extensions map to MarkdownStrategy."""

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -528,6 +528,74 @@ More color."""
         assert '> "Closing quote with organization."' in result
         assert "Leading colour prose." in result
 
+    # === MARKDOWN LINK TARGETS ===
+
+    def test_link_url_preserved(self, strategy, corrector):
+        """URL inside a markdown link target should not be corrected."""
+        text = "See [the talk](https://example.com/modeled-on-the-bar-exam/) for details."
+        result, changes = strategy.process(text, corrector)
+        assert "https://example.com/modeled-on-the-bar-exam/" in result
+        assert "modelled-on" not in result
+
+    def test_link_text_still_corrected(self, strategy, corrector):
+        """Link text should still be corrected; only the target is preserved."""
+        text = "[The organized guide](https://example.com/page) explains color."
+        result, changes = strategy.process(text, corrector)
+        assert "[The organised guide]" in result
+        assert "(https://example.com/page)" in result
+        assert "explains colour" in result
+
+    def test_link_title_preserved(self, strategy, corrector):
+        """A link title inside the parens should be preserved."""
+        text = '[text](https://example.com/color "the color page") then color prose.'
+        result, changes = strategy.process(text, corrector)
+        assert '(https://example.com/color "the color page")' in result
+        assert "then colour prose" in result
+
+    def test_image_syntax_url_preserved(self, strategy, corrector):
+        """Image syntax ![alt](url) should preserve the URL."""
+        text = "![organized diagram](https://example.com/organized-chart.png) is color-coded."
+        result, changes = strategy.process(text, corrector)
+        assert "(https://example.com/organized-chart.png)" in result
+        assert "is colour-coded" in result
+
+    def test_multiple_links_on_one_line(self, strategy, corrector):
+        """Multiple links on the same line should each have their URLs preserved."""
+        text = "Read [one](https://a.com/organized) and [two](https://b.com/analyzed) then color."
+        result, changes = strategy.process(text, corrector)
+        assert "(https://a.com/organized)" in result
+        assert "(https://b.com/analyzed)" in result
+        assert "then colour" in result
+
+    def test_link_inside_fenced_code_block_preserved_wholesale(self, strategy, corrector):
+        """A link inside a fenced code block is preserved by the code-block handler; nothing is corrected."""
+        text = "```\n[text](https://example.com/organized) and color\n```\n\nThe color works."
+        result, changes = strategy.process(text, corrector)
+        assert "[text](https://example.com/organized) and color" in result  # Inside fence, untouched
+        assert "The colour works" in result  # Prose after fence, corrected
+
+    def test_link_inside_blockquote_preserved_wholesale(self, strategy, corrector):
+        """A link inside a blockquote line is preserved verbatim (blockquote wins)."""
+        text = "> See [the talk](https://example.com/organized) for color.\n\nNormal color prose."
+        result, changes = strategy.process(text, corrector)
+        assert "> See [the talk](https://example.com/organized) for color." in result
+        assert "Normal colour prose" in result
+
+    def test_link_with_inline_code_in_text_preserves_url(self, strategy, corrector):
+        """A link whose text contains inline code still preserves the URL in the following segment."""
+        text = "Call [`colorize`](https://example.com/organized-api) to color things."
+        result, changes = strategy.process(text, corrector)
+        assert "`colorize`" in result  # Inline code untouched
+        assert "(https://example.com/organized-api)" in result  # URL preserved via later segment
+        assert "to colour things" in result  # Trailing prose corrected
+
+    def test_html_anchor_url_preserved(self, strategy, corrector):
+        """HTML <a href=\"...\"> URLs remain preserved via the HTML-tag skip (regression guard)."""
+        text = '<a href="https://example.com/organized">click</a> for color.'
+        result, changes = strategy.process(text, corrector)
+        assert 'href="https://example.com/organized"' in result
+        assert "for colour" in result
+
 
 class TestMarkdownStrategyMapping:
     """Test that markdown file extensions map to MarkdownStrategy."""


### PR DESCRIPTION
## Summary

The markdown strategy corrects spelling inside markdown link URLs, silently breaking external links. A US-spelled slug like `/modeled-on-foo/` inside `[text](https://example.com/modeled-on-foo/)` becomes `/modelled-on-foo/` — a working link turned 404.

HTML anchor tags (`<a href="...">`) are already safe via #11's tag-skip. Only markdown-syntax link targets leak through.

## Fix

Nest a split on `](url)` inside the existing HTML-tag split in `MarkdownStrategy.process()`. The entire `](url)` / `](url "title")` span is preserved verbatim; link text and surrounding prose are still corrected normally. Image syntax `![alt](url)` is covered by the same pattern (the `](url)` portion matches identically).

Regex: `r'(\]\([^)]*\))'` — matches `](…)` where the URL has no `)`. Standard CommonMark; URLs with literal `)` require backslash escaping or `<…>` wrapping, which are out of scope.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `See [talk](https://ex.com/modeled-on-x/) on color.` | `See [talk](https://ex.com/modelled-on-x/) on colour.` | `See [talk](https://ex.com/modeled-on-x/) on colour.` |
| `[The organized guide](https://ex.com/page) on color.` | `[The organised guide](https://ex.com/page) on colour.` | `[The organised guide](https://ex.com/page) on colour.` |
| `![organized diagram](https://ex.com/organized.png)` | `![organised diagram](https://ex.com/organised.png)` | `![organised diagram](https://ex.com/organized.png)` |

Link text is still corrected; only the `](url)` target is preserved.

## Interaction coverage (per #24's concern)

`MarkdownStrategy.process()` already juggles fences, indented blocks, inline code, blockquotes, HTML tags (including multi-line tags from #24). Added tests exercise each overlap:

- Link inside fenced code block — code block wins, whole thing preserved
- Link inside blockquote line — blockquote wins, line preserved verbatim
- Link whose text contains inline code (`` [`code`](url) ``) — inline-code handler consumes the backticks; the trailing `](url)` segment still matches the new split and is preserved
- HTML anchor `<a href="…">` — still preserved via the tag split (regression guard)
- Multiple links on one line — each target preserved independently
- Link title `[text](url "title")` — title falls inside the `](…)` match, preserved

No changes to the existing scan/lookahead machinery, so multi-line HTML tag handling from #24 is untouched.

## Known limitations (out of scope)

- Reference-style link definitions `[ref]: https://…` at line start are not yet handled — if a reference URL contains a US spelling it will still be corrected. Happy to follow up in a separate PR if you'd like.
- Bare URLs in prose (`visit https://ex.com/organized`) are also not handled; CommonMark-style autolinks `<https://ex.com/organized>` are already preserved via the HTML-tag skip.
- Malformed links missing a closing `)` (`[text](https://ex.com/organized and color`) fall through the link-target split; the URL fragment is treated as prose and corrected. Valid CommonMark inputs are unaffected — this is graceful degradation, not a silent failure in the common case.

## Observed-behaviour note

A wiki-style URL with a single nested `(…)` like `https://en.wikipedia.org/wiki/Link_(organized)` happens to preserve correctly: the regex `[^)]*` stops at the inner `)`, and the stray outer `)` falls through as prose with nothing to correct. Pinned as a regression test so a future regex tightening doesn't silently break it. URLs with deeper nesting or unescaped trailing parens remain out of scope.

## Test plan

- [x] 10 new tests in `TestMarkdownStrategy` under a new `=== MARKDOWN LINK TARGETS ===` section: URL preserved, link text still corrected, link title preserved, image syntax, multiple links per line, link-in-fence, link-in-blockquote, link with inline code in text, HTML anchor regression guard, wiki-style nested-paren URL.
- [x] Full suite: 226 passed, 1 skipped. All pre-existing tests unaffected.