### PR TITLE
Fix CodeStrategy treating Rust attributes as line comments (#33)

### DIFF
--- a/britfix_core.py
+++ b/britfix_core.py
@@ -866,17 +866,27 @@ class JSONStrategy(FileProcessingStrategy):
 
 def _is_hash_non_comment_construct(content: str, i: int) -> bool:
     """Returns True for ``#``-prefixed tokens that are NOT line comments:
-    Rust outer/inner attributes (``#[...]``, ``#![...]``) and file-leading
-    shebangs (``#!...`` at offset 0). Localised here so future per-language
-    comment handling can replace this with a syntax table.
+    Rust outer/inner attributes (``#[...]``, ``#![...]``) when they are
+    the first non-whitespace token on a line, and file-leading shebangs
+    (``#!...`` at offset 0). Localised here so future per-language comment
+    handling can replace this with a syntax table.
+
+    The line-start restriction matters: an inline Python/Ruby/shell comment
+    like ``x = 1  #[TODO fix the behavior]`` is still a real comment and
+    must keep being processed. Indented Rust attributes (e.g. inside a
+    struct body) start their own line and so are still recognised.
 
     Note: Rust raw strings (``r#"..."#``) are not handled here and remain a
     known edge case for a future ``RustStrategy``.
     """
-    if content[i:i+2] == '#[':
-        return True
-    if content[i:i+3] == '#![':
-        return True
+    if content[i:i+2] == '#[' or content[i:i+3] == '#![':
+        # Walk back over any leading whitespace on the current line.
+        j = i - 1
+        while j >= 0 and content[j] in (' ', '\t'):
+            j -= 1
+        # Line-start = either start of file, or the previous non-space
+        # char is a newline.
+        return j < 0 or content[j] == '\n'
     if i == 0 and content[i:i+2] == '#!':
         return True
     return False

--- a/britfix_core.py
+++ b/britfix_core.py
@@ -864,6 +864,24 @@ class JSONStrategy(FileProcessingStrategy):
                     self._process_json_value(item, corrector, change_tracker)
 
 
+def _is_hash_non_comment_construct(content: str, i: int) -> bool:
+    """Returns True for ``#``-prefixed tokens that are NOT line comments:
+    Rust outer/inner attributes (``#[...]``, ``#![...]``) and file-leading
+    shebangs (``#!...`` at offset 0). Localised here so future per-language
+    comment handling can replace this with a syntax table.
+
+    Note: Rust raw strings (``r#"..."#``) are not handled here and remain a
+    known edge case for a future ``RustStrategy``.
+    """
+    if content[i:i+2] == '#[':
+        return True
+    if content[i:i+3] == '#![':
+        return True
+    if i == 0 and content[i:i+2] == '#!':
+        return True
+    return False
+
+
 class CodeStrategy(FileProcessingStrategy):
     """
     Process code files - only convert prose in comments and docstrings.
@@ -934,8 +952,10 @@ class CodeStrategy(FileProcessingStrategy):
                 i = end
                 continue
 
-            # Check for line comments (# or //)
-            if content[i] == '#' or content[i:i+2] == '//':
+            # Check for line comments (# or //). `#` is excluded for Rust
+            # attribute syntax and file-leading shebangs (see helper above).
+            if (content[i] == '#' and not _is_hash_non_comment_construct(content, i)) \
+                    or content[i:i+2] == '//':
                 # Find end of line
                 end = content.find('\n', i)
                 if end == -1:

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -675,6 +675,43 @@ class TestLanguageSpecificComments:
         assert "behaviour" in result
 
 
+class TestRustAttributesAndShebangs:
+    """Rust attribute syntax (#[...], #![...]) and file-leading shebangs
+    must not be classified as #-prefixed line comments. See issue #33."""
+
+    @pytest.fixture
+    def strategy(self):
+        return CodeStrategy()
+
+    def test_rust_derive_attribute_preserved(self, strategy, corrector):
+        code = "#[derive(Debug, Clone, Serialize)]"
+        result, _ = strategy.process(code, corrector)
+        assert result == code
+
+    def test_rust_inner_attribute_preserved(self, strategy, corrector):
+        code = '#![cfg_attr(feature = "serde", derive(Serialize))]'
+        result, _ = strategy.process(code, corrector)
+        assert result == code
+
+    def test_mixed_rust_attribute_and_doc_comment(self, strategy, corrector):
+        code = "#[derive(Serialize)]\n// The behavior is favorable"
+        result, _ = strategy.process(code, corrector)
+        assert "#[derive(Serialize)]" in result
+        assert "behaviour is favourable" in result
+
+    def test_shebang_preserved_but_hash_comment_below_converted(self, strategy, corrector):
+        code = "#!/usr/bin/env python3\n# The behavior is favorable"
+        result, _ = strategy.process(code, corrector)
+        assert result.startswith("#!/usr/bin/env python3")
+        assert "behaviour is favourable" in result
+
+    def test_mid_line_hash_bang_still_treated_as_comment(self, strategy, corrector):
+        # `#!` not at offset 0 is a real comment in Python/Ruby/shell.
+        code = "x = 1  #! The behavior is favorable"
+        result, _ = strategy.process(code, corrector)
+        assert "behaviour is favourable" in result
+
+
 class TestEdgeCases:
     """Edge cases and tricky scenarios."""
     

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -711,6 +711,24 @@ class TestRustAttributesAndShebangs:
         result, _ = strategy.process(code, corrector)
         assert "behaviour is favourable" in result
 
+    def test_mid_line_hash_bracket_still_treated_as_comment(self, strategy, corrector):
+        # Inline `#[` is a real Python/Ruby/shell comment, not a Rust attribute.
+        code = "x = 1  #[ The behavior is favorable ]"
+        result, _ = strategy.process(code, corrector)
+        assert "behaviour is favourable" in result
+
+    def test_indented_rust_attribute_preserved(self, strategy, corrector):
+        # Real Rust: attributes on struct fields are indented but still start
+        # their own line — they must NOT be processed as comments.
+        code = (
+            "pub struct Foo {\n"
+            "    #[serde(rename = \"Serialize\")]\n"
+            "    pub bar: String,\n"
+            "}\n"
+        )
+        result, _ = strategy.process(code, corrector)
+        assert '#[serde(rename = "Serialize")]' in result
+
 
 class TestEdgeCases:
     """Edge cases and tricky scenarios."""


### PR DESCRIPTION
## Summary

- Closes #33. `CodeStrategy` was classifying any `#` as a Python/Ruby/shell line comment, which caused Rust attribute syntax (`#[...]`, `#![...]`) to be processed as prose. The headline failure: `#[derive(Debug, Clone, Serialize, Deserialize)]` became `Serialise`, breaking serde compilation.
- Adds a small `_is_hash_non_comment_construct` helper that recognises Rust outer/inner attributes and file-leading shebangs, and narrows the line-comment condition to skip them. Mid-line `#!` is intentionally still treated as a comment so legitimate Python/Ruby/shell comments like `x = 1  #! TODO` keep converting.
- Five targeted tests, including a regression test that locks in the mid-line `#!` behaviour so the rule cannot silently widen later.

## Known unsolved edge

Rust raw strings (`r#"..."#`) are not understood by `CodeStrategy` — out of scope for this fix; flagged in the helper docstring as future `RustStrategy` territory.

## Test plan

- [x] `pytest test_britfix.py` — 232 passed, 1 skipped, 0 failed
- [x] End-to-end repro from issue #33: write the snippet to a tmp `.rs` file, run britfix; `Serialize` is preserved (`No changes needed`)
- [x] Shebang sanity check: `#!/usr/bin/env python3\n# The behavior is favorable\n` — shebang preserved, comment correctly rewritten to `behaviour`/`favourable`