### PR TITLE
Remove ton -> tonne conflation (different units, not a spelling pair)

### DIFF
--- a/spelling-mapper.json
+++ b/spelling-mapper.json
@@ -1653,8 +1653,6 @@
   "theorizing": "theorising",
   "tire": "tyre",
   "tires": "tyres",
-  "ton": "tonne",
-  "tons": "tonnes",
   "toweled": "towelled",
   "toweling": "towelling",
   "toxemia": "toxaemia",


### PR DESCRIPTION
## Summary

Removes two dictionary entries that convert `ton` → `tonne` and `tons` → `tonnes`.

## Why

Unlike everything else in the dictionary, these aren't BrE-vs-AmE spellings of one word — **`ton` and `tonne` are different units of mass**, and *both* spellings are standard in British English:

- **ton** — an imperial unit. The British long ton is 2,240 lb (~1,016 kg); the US short ton is 2,000 lb (~907 kg). Spelled "ton" in both dialects.
- **tonne** — the metric unit, exactly 1,000 kg ("metric ton"). Spelled "tonne" in BrE; AmE uses "tonne" or "metric ton".

So there's no AmE→BrE correction to make here, and the mapping does real damage:

1. **It silently changes the quantity.** A 2,240 lb long ton becomes a 1,000 kg tonne — a ~1.6% understatement of an imperial figure, or worse against a US short ton.
2. **It mangles the figurative sense**, which is *always* "ton" in British English: "a ton of work", "lost a ton of weight", "tons of fun" are correct BrE and must not become "a tonne of work" / "tonnes of fun". This is where it bites most in ordinary prose.

Oxford, Collins and Cambridge all list `ton` and `tonne` as **separate headwords with separate definitions**, not as a UK/US spelling pair (contrast genuine pairs like `colour`/`color`).

## Scope

Two lines:
- `ton` → `tonne`
- `tons` → `tonnes`

## Test plan

- [x] JSON parses cleanly (`python3 -c 'import json; json.load(open("spelling-mapper.json"))'` — 1936 entries after removal)
- [x] No existing tests reference the removed words (`grep -nE '\bton\b|tonne|\btons\b' test_britfix.py` — no matches)
- [x] Suite: `233 passed, 1 skipped`. One pre-existing failure on `main` (`test_end_to_end_phrase_in_britfixignore`, a `program`/`programme` ignore-scope case) reproduces on a clean checkout and is unrelated to this change.