### PR TITLE
Remove archaic wagon -> waggon mapping

### DIFF
--- a/spelling-mapper.json
+++ b/spelling-mapper.json
@@ -1765,8 +1765,6 @@
   "vulgarized": "vulgarised",
   "vulgarizes": "vulgarises",
   "vulgarizing": "vulgarising",
-  "wagon": "waggon",
-  "wagons": "waggons",
   "watercolor": "watercolour",
   "watercolors": "watercolours",
   "weaseled": "weaselled",


### PR DESCRIPTION
## What

Removes two mappings from `spelling-mapper.json`:

```
"wagon": "waggon",
"wagons": "waggons",
```

## Why

`waggon` is a dated British variant, not a live BrE vs AmE difference. Oxford, Collins and Cambridge all give **wagon** as the headword, with no UK/US dialect labelling (in contrast to genuine splits like `colour`/`color`). `waggon` now reads as affectation.

This is the same logic as #16, #32 and #36 (`-exion` / `ancle` / `almanack` / `-gramme`): the form is archaic in *both* dialects, so the mapping wrongly rewrites the standard modern spelling into the dated form — e.g. a normaliser turning "loading wagon" into "loading waggon".

Both `wagon` and `wagons` are removed; there is no legitimate `-ggon` term to preserve.

## Tests

No test changes — the suite has no fixtures asserting the removed mappings. Full suite passes apart from one pre-existing failure on `main` (`TestPhraseIntegration::test_end_to_end_phrase_in_britfixignore`, unrelated to this change).