### PR TITLE
Remove groin -> groyne conflation (different words, not a spelling pair)

### DIFF
--- a/spelling-mapper.json
+++ b/spelling-mapper.json
@@ -711,8 +711,6 @@
   "grays": "greys",
   "griffin": "gryphon",
   "griffins": "gryphons",
-  "groin": "groyne",
-  "groins": "groynes",
   "groveled": "grovelled",
   "groveling": "grovelling",
   "grueling": "gruelling",


### PR DESCRIPTION
## Summary

Removes two dictionary entries that convert `groin` → `groyne` and `groins` → `groynes`.

## Why

`groin` and `groyne` are not a BrE-vs-AmE spelling pair for one word. The AmE→BrE relationship holds for **one narrow sense only**, and the mapping fires on all of them:

- **groyne** — a low wall or timber barrier built out into the sea to check erosion and drift. This is the coastal-engineering sense, and it is the *only* sense Collins and Cambridge give under the headword `groyne`. AmE spells this one `groin`, so here the mapping is correct.
- **groin** — the fold where the thigh meets the abdomen. Standard in British English. Nobody writes "a groyne strain".
- **groin** — in architecture, the projecting edge where two vaults intersect ("groin vault"). Also spelled `groin` in BrE.

Wiktionary makes the split explicit: `groin` is marked "US standard spelling of groyne" **only under the coastal-structure etymology**, not under the anatomical or architectural ones.

Since a word-level mapper cannot tell the senses apart, and the anatomical sense overwhelmingly dominates ordinary prose, the mapping corrupts far more text than it fixes — silently turning "groin injury" into "groyne injury", which reads as a typo rather than as British English. Removing it is the lower-error default; the coastal sense is rare enough that authors writing about breakwaters can spell it themselves.

Same class of fix as #37 (`ton`/`tonne`): distinct words that happen to share a spelling in AmE, rather than one word with two dialect spellings.

## Scope

Two lines:
- `groin` → `groyne`
- `groins` → `groynes`

## Test plan

- [x] JSON parses cleanly (`python3 -c 'import json; json.load(open("spelling-mapper.json"))'` — 1936 entries after removal)
- [x] No existing tests reference the removed words (`grep -nE 'groin|groyne' test_britfix.py` — no matches)
- [x] Behaviour check: `groin pain, both groins tender. color organize.` → `groin pain, both groins tender. colour organise.` — target words preserved, unrelated mappings still fire
- [x] Suite: `233 passed, 1 skipped`. One failure (`test_end_to_end_phrase_in_britfixignore`, a `program`/`programme` ignore-scope case) reproduces on a clean `main` checkout and is unrelated to this change.