### PR TITLE
Add regression tests locking in removed dictionary mappings

### DIFF
--- a/test_britfix.py
+++ b/test_britfix.py
@@ -135,9 +135,8 @@ class TestRemovedMappings:
     ]
 
     @pytest.mark.parametrize("word", REMOVED)
-    def test_key_absent_from_dictionary(self, word):
-        mappings = load_spelling_mappings()
-        assert word not in mappings, f"'{word}' was deliberately removed; do not reintroduce"
+    def test_key_absent_from_dictionary(self, corrector, word):
+        assert word not in corrector.dictionary, f"'{word}' was deliberately removed; do not reintroduce"
 
     @pytest.mark.parametrize("word", REMOVED)
     def test_word_passes_through_unchanged(self, corrector, word):

--- a/test_britfix.py
+++ b/test_britfix.py
@@ -112,6 +112,46 @@ class TestPractiseFamily:
         assert len(changes) == 0
 
 
+class TestRemovedMappings:
+    """Mappings deliberately removed from the dictionary must stay removed.
+
+    Each of these was deleted because it wasn't a genuine US-to-UK spelling
+    pair: archaic in both dialects (-gramme, waggon), distinct words/units
+    (ton/tonne, groin/groyne), identical in both dialects (licensed/licensing),
+    or running in the wrong direction (practise family). See PRs #16, #32,
+    #36, #37, #40, #41, #42, #44.
+    """
+
+    REMOVED = [
+        "gram", "grams", "kilogram", "kilograms",
+        "milligram", "milligrams", "centigram", "centigrams",
+        "ton", "tons",
+        "wagon", "wagons",
+        "licensed", "licensing",
+        "practise", "practised", "practises", "practising",
+        "groin", "groins",
+        "almanac", "almanacs", "ankle",
+        "deflection", "inflection", "inflections", "reflection",
+    ]
+
+    @pytest.mark.parametrize("word", REMOVED)
+    def test_key_absent_from_dictionary(self, word):
+        mappings = load_spelling_mappings()
+        assert word not in mappings, f"'{word}' was deliberately removed; do not reintroduce"
+
+    @pytest.mark.parametrize("word", REMOVED)
+    def test_word_passes_through_unchanged(self, corrector, word):
+        result, changes = corrector.correct_text(f"the {word} here")
+        assert result == f"the {word} here"
+        assert len(changes) == 0
+
+    def test_kept_neighbours_still_convert(self, corrector):
+        # The removals must not take out the genuine dialect pairs nearby.
+        assert corrector.correct_text("aerogram")[0] == "aerogramme"
+        assert corrector.correct_text("The program is great.")[0] == "The programme is great."
+        assert corrector.correct_text("a license")[0] == "a licence"
+
+
 class TestCodeStrategy:
     """CodeStrategy should only convert in comments/docstrings, not string literals."""
     


### PR DESCRIPTION
## What

Adds `TestRemovedMappings`: parameterised regression tests asserting that every dictionary entry deliberately removed in #16, #32, #36, #37, #40, #41, #42 and #44 stays removed.

## Why

Those PRs deleted 27 mappings that weren't genuine US-to-UK spelling pairs (archaic forms, distinct words/units, wrong-direction conversions), but only #42/#43 added tests. A passing suite therefore didn't prove the removals held, and nothing prevented a future dictionary import or well-meaning addition from quietly reintroducing, say, `ton -> tonne` or `licensed -> licenced`.

## How

For each removed key the tests assert both that the key is absent from `spelling-mapper.json` and that the word passes through `correct_text` unchanged, plus a check that the deliberately kept neighbours (`aerogram -> aerogramme`, `program -> programme`, `license -> licence`) still convert.

Suite: 307 passed, 1 skipped.
