### PR TITLE
Add config.local.json for private exclude_paths entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local, per-machine config (never committed, never bundled)
+/config.local.json
+
 # Build artifacts
 build/
 dist/

--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ Notes:
 - This only affects the hook; the `britfix` CLI processes whatever it is
   given.
 
+### Local overrides (`config.local.json`)
+
+To keep private paths out of the repo, create a gitignored `config.local.json`
+next to `config.json`. Its `exclude_paths` entries are appended to the shared
+list:
+
+```json
+{
+  "exclude_paths": ["/Users/me/Private/Transcripts/"]
+}
+```
+
+The local file may only set `exclude_paths` (and comment keys). Anything
+else, in particular `strategies`, is a fatal config error: strategies must stay
+in the shared `config.json`, which the CLI also reads, so a hook-only
+override would make the two disagree about how a file should be handled. The
+file is never bundled into the built binary.
+
 ## Hook Integration
 
 The `britfix_hook.py` script integrates with tools that support hooks to automatically fix spellings when files are written.

--- a/britfix_hook.py
+++ b/britfix_hook.py
@@ -69,15 +69,16 @@ def merge_local_config(config: dict, local_path: Path) -> dict:
     try:
         with open(local_path) as f:
             local = json.load(f)
-    except json.JSONDecodeError as e:
-        log(f"[Britfix Error] Invalid JSON in {local_path.name}: {e}")
+    except (json.JSONDecodeError, OSError) as e:
+        log(f"[Britfix Error] Cannot read {local_path.name}: {e}")
         sys.exit(1)
 
     if not isinstance(local, dict):
         log(f"[Britfix Error] {local_path.name} must be a JSON object")
         sys.exit(1)
 
-    unknown = [k for k in local if k != 'exclude_paths' and 'comment' not in k]
+    unknown = [k for k in local
+               if k != 'exclude_paths' and k != 'comment' and not k.endswith('_comment')]
     if unknown:
         log(f"[Britfix Error] {local_path.name} may only set 'exclude_paths' (got {sorted(unknown)})")
         sys.exit(1)

--- a/britfix_hook.py
+++ b/britfix_hook.py
@@ -55,9 +55,40 @@ def path_is_excluded(file_path: str, exclude_paths: list) -> bool:
     return any(excl in resolved for excl in exclude_paths)
 
 
+def merge_local_config(config: dict, local_path: Path) -> dict:
+    """Merge an optional, gitignored config.local.json into the loaded config.
+
+    The local file may ONLY extend `exclude_paths` (plus comment keys) — its
+    entries are appended to the base list. Other keys are a fatal error rather
+    than being silently ignored: in particular `strategies` must stay in the
+    shared config, because the CLI loads config.json independently and a
+    hook-only override would desync the two."""
+    if not local_path.exists():
+        return config
+
+    try:
+        with open(local_path) as f:
+            local = json.load(f)
+    except json.JSONDecodeError as e:
+        log(f"[Britfix Error] Invalid JSON in {local_path.name}: {e}")
+        sys.exit(1)
+
+    if not isinstance(local, dict):
+        log(f"[Britfix Error] {local_path.name} must be a JSON object")
+        sys.exit(1)
+
+    unknown = [k for k in local if k != 'exclude_paths' and 'comment' not in k]
+    if unknown:
+        log(f"[Britfix Error] {local_path.name} may only set 'exclude_paths' (got {sorted(unknown)})")
+        sys.exit(1)
+
+    config['exclude_paths'] = config['exclude_paths'] + validate_exclude_paths(local.get('exclude_paths', []))
+    return config
+
+
 # Load and validate config
 def load_config():
-    """Load and validate config.json. Exits if invalid."""
+    """Load and validate config.json (plus optional config.local.json). Exits if invalid."""
     config_path = HOOK_DIR / 'config.json'
 
     if not config_path.exists():
@@ -76,6 +107,7 @@ def load_config():
         sys.exit(1)
 
     config['exclude_paths'] = validate_exclude_paths(config.get('exclude_paths', []))
+    config = merge_local_config(config, HOOK_DIR / 'config.local.json')
 
     return config
 

--- a/test_britfix_hook.py
+++ b/test_britfix_hook.py
@@ -124,6 +124,22 @@ def test_merge_local_invalid_json_is_fatal(tmp_path):
         h.merge_local_config(_base_config(), _local(tmp_path, "{not json"))
 
 
+def test_merge_local_unreadable_file_is_fatal(tmp_path):
+    # An existing-but-unreadable local file (here: a directory) must fail
+    # closed with a clear error, not crash with an uncaught OSError.
+    p = tmp_path / "config.local.json"
+    p.mkdir()
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), p)
+
+
+def test_merge_local_comment_substring_key_is_fatal(tmp_path):
+    # Only 'comment' and '*_comment' are comment keys; a key merely containing
+    # the substring must still be rejected.
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), _local(tmp_path, {"uncommented": True}))
+
+
 def test_merge_local_non_object_is_fatal(tmp_path):
     with pytest.raises(SystemExit):
         h.merge_local_config(_base_config(), _local(tmp_path, ["/private/"]))

--- a/test_britfix_hook.py
+++ b/test_britfix_hook.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Tests for britfix_hook — exclude_paths validation and path-based skipping."""
+import json
 import pytest
 import britfix_hook as h
 
@@ -89,3 +90,52 @@ def test_process_runs_when_not_excluded(monkeypatch, md_file):
     monkeypatch.setattr(h, "SUPPORTED_EXTENSIONS", {".md"})
     h.process_posttooluse(_payload(md_file))
     assert calls == [md_file]  # not excluded -> britfix invoked
+
+
+# --- merge_local_config (config.local.json) --------------------------------
+
+def _base_config():
+    return {"strategies": {}, "exclude_paths": ["/shared/"]}
+
+
+def _local(tmp_path, content):
+    p = tmp_path / "config.local.json"
+    p.write_text(content if isinstance(content, str) else json.dumps(content))
+    return p
+
+
+def test_merge_local_missing_file_is_noop(tmp_path):
+    cfg = _base_config()
+    assert h.merge_local_config(cfg, tmp_path / "config.local.json") == _base_config()
+
+
+def test_merge_local_extends_exclude_paths(tmp_path):
+    cfg = h.merge_local_config(_base_config(), _local(tmp_path, {"exclude_paths": ["/private/"]}))
+    assert cfg["exclude_paths"] == ["/shared/", "/private/"]
+
+
+def test_merge_local_comment_keys_allowed(tmp_path):
+    cfg = h.merge_local_config(_base_config(), _local(tmp_path, {"comment": "mine", "exclude_paths": []}))
+    assert cfg["exclude_paths"] == ["/shared/"]
+
+
+def test_merge_local_invalid_json_is_fatal(tmp_path):
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), _local(tmp_path, "{not json"))
+
+
+def test_merge_local_non_object_is_fatal(tmp_path):
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), _local(tmp_path, ["/private/"]))
+
+
+def test_merge_local_strategies_override_is_fatal(tmp_path):
+    # strategies must stay in the shared config: the CLI loads config.json
+    # independently, so a hook-only override would desync the two.
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), _local(tmp_path, {"strategies": {}}))
+
+
+def test_merge_local_entries_are_validated(tmp_path):
+    with pytest.raises(SystemExit):
+        h.merge_local_config(_base_config(), _local(tmp_path, {"exclude_paths": [""]}))


### PR DESCRIPTION
## What

Follow-up promised in #38: an optional, gitignored `config.local.json` next to `config.json` whose `exclude_paths` entries are appended to the shared list, so users can keep private paths (personal transcript folders etc.) out of the repo.

## Design decisions

- **`exclude_paths` only.** The original #38 description floated letting the local file also override `strategies`. That is deliberately not supported: the hook and the `britfix` CLI load configuration independently (`britfix_hook.py` vs `britfix_core.py`), so a hook-only strategies override could pass the hook's extension filter yet have the converter treat the file differently. Until config loading is centralised, strategies stay in the shared `config.json`. A local file containing anything other than `exclude_paths` (or comment keys) is a fatal config error rather than being silently ignored.
- **Fail closed throughout**, matching #38: invalid JSON, a non-object root, or invalid entries (non-string, empty string) stop the hook.
- **Never bundled.** The PyInstaller build continues to package only `config.json`; the local file stays on the machine it was written on. Discovery is `HOOK_DIR`-adjacent, which is sound because `run-hook.sh` always runs the hook from the repo checkout.
- `.gitignore` gains a root-anchored `/config.local.json`; README documents the mechanism and its limits.

## Tests

Seven new tests covering: missing file no-op, extension merging, comment keys, invalid JSON, non-object root, `strategies` rejection, and entry validation. Suite: 259 passed, 1 skipped. Also smoke-tested live: a local file extends `EXCLUDE_PATHS` on import, and a `strategies` key aborts with a clear error.
